### PR TITLE
Don't re-update hash with "!" if hash was set without "!"

### DIFF
--- a/route/route.js
+++ b/route/route.js
@@ -527,7 +527,9 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 				// gets called with the serialized can.route data after a route has changed
 				// returns what the url has been updated to (for matching purposes)
 				setURL: function (path) {
-					location.hash = "#!" + path;
+					if(location.hash !== "#" + path) {
+						location.hash = "!" + path;
+					}
 					return path;
 				},
 				root: "#!"

--- a/route/route_test.js
+++ b/route/route_test.js
@@ -573,7 +573,12 @@ steal("can/route", "can/test", function () {
 				iCanRoute.attr('path', 'foo');
 				setTimeout(function() {
 					var counter = 0;
-					equal(loc.hash, '#!foo');
+					try {
+						equal(loc.hash, '#!foo');
+					} catch(e) {
+						start();
+						throw e;
+					}
 
 					iCanRoute.bind("change", function() {
 						counter++;
@@ -581,9 +586,12 @@ steal("can/route", "can/test", function () {
 
 					loc.hash = "bar";
 					setTimeout(function() {
-						equal(loc.hash, '#bar');
-						equal(counter, 1); //sanity check -- bindings only ran once before this change.
-						start();
+						try {
+							equal(loc.hash, '#bar');
+							equal(counter, 1); //sanity check -- bindings only ran once before this change.
+						} finally {
+							start();
+						}
 					}, 100);
 				}, 100);
 			};

--- a/route/route_test.js
+++ b/route/route_test.js
@@ -562,6 +562,37 @@ steal("can/route", "can/test", function () {
 			iframe.src = can.test.path("route/testing.html?1");
 			can.$("#qunit-test-area")[0].appendChild(iframe);
 		});
+
+		test("hash doesn't update to itself with a !", function() {
+			stop();
+			window.routeTestReady = function (iCanRoute, loc) {
+
+				iCanRoute.ready();
+				iCanRoute(":path");
+
+				iCanRoute.attr('path', 'foo');
+				setTimeout(function() {
+					var counter = 0;
+					equal(loc.hash, '#!foo');
+
+					iCanRoute.bind("change", function() {
+						counter++;
+					});
+
+					loc.hash = "bar";
+					setTimeout(function() {
+						equal(loc.hash, '#bar');
+						equal(counter, 1); //sanity check -- bindings only ran once before this change.
+						start();
+					}, 100);
+				}, 100);
+			};
+			var iframe = document.createElement('iframe');
+			iframe.src = can.test.path("route/testing.html?1");
+			can.$("#qunit-test-area")[0].appendChild(iframe);
+		});
+
+
 	}
 
 	test("escaping periods", function () {


### PR DESCRIPTION
This prevents putting two history entries in to the window history for a route update.

Note that prior to this fix, it wouldn't cause the route bindings to fire twice, since once deparamed, it would be the same route.  It just makes two history entries.