### PR TITLE
Ensure can-value bound input stay in sync with compute

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -236,8 +236,15 @@ steal("can/util", "can/view/mustache", "can/control", function (can) {
 			if (!this.element) {
 				return;
 			}
+			var el = this.element[0];
+			
 			// Set the value of the attribute passed in to reflect what the user typed
-			this.options.value(this.element[0].value);
+			var newVal = this.options.value(el.value);
+			
+			// If the newVal isn't the same as the input, set it's value
+			if(el.value !== newVal) {
+				el.value = newVal;
+			}
 		}
 	}),
 	// ### Checked 

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -439,5 +439,34 @@ steal("can/view/bindings", "can/map", "can/test", function (special) {
 		equal(map.attr("age"), "32", "updated from contenteditable");
 	});
 
+	test("can-value compute rejects new value (#887)", function() {
+		var template = can.view.mustache("<input can-value='age'/>");
+
+		// Compute only accepts numbers
+		var compute = can.compute(30, function(newVal, oldVal) {
+			if(isNaN(+newVal)) {
+				return oldVal;
+			} else {
+				return +newVal;
+			}
+		});
+
+		var frag = template({
+			age: compute
+		});
+
+		var ta = document.getElementById("qunit-test-area");
+		ta.appendChild(frag);
+
+		var input = ta.getElementsByTagName("input")[0];
+
+		// Set to non-number
+		input.value = "30f";
+		can.trigger(input, "change");
+
+		equal(compute(), 30, "Still the old value");
+		equal(input.value, "30", "Text input has also not changed");
+	});
+
 
 });


### PR DESCRIPTION
It's possible for a `can-value` bound input to become out of sync with it's underlying data if that data is a compute with a setter function. The setter function might reject the user's input or set the value to something else entirely.

Previously we were assuming that the compute's new value would always be the same as the input's value. This checks to make sure that the values are the same, otherwise it sets the input's value to reflect the *actual* value of the compute.

Fixes #887