### PR TITLE
951 can model promises

### DIFF
--- a/model/promise/promise.html
+++ b/model/promise/promise.html
@@ -29,7 +29,7 @@
   {{/if}}
 
   {{#if user.isRejected}}
-    We were unable to load the user because {{user.reason.responseJSON.message}}
+    {{user.reason.responseJSON.message}}
   {{/if}}
 
 </site-app> 
@@ -62,10 +62,9 @@ steal("can","can/util/fixture","can/model/promise",function(){
   });
 
   can.fixture("PUT /users/{id}", function(request, response){
-
     response(404,"error",{message:"resource can't be saved"});
-    
   });
+
   can.fixture.delay = 1500;
   
   User = can.Model.extend({

--- a/model/promise/promise.html
+++ b/model/promise/promise.html
@@ -60,9 +60,16 @@ steal("can","can/util/fixture","can/model/promise",function(){
       response(404,"error",{message:"resource does not exist"});
     }
   });
+
+  can.fixture("PUT /users/{id}", function(request, response){
+
+    response(404,"error",{message:"resource can't be saved"});
+    
+  });
   can.fixture.delay = 1500;
   
   User = can.Model.extend({
+    update : "PUT /users/{id}",
     findOne: "GET /users/{id}"
   },{});
   

--- a/model/promise/promise.html
+++ b/model/promise/promise.html
@@ -76,13 +76,13 @@ steal("can","can/util/fixture","can/model/promise",function(){
     tag: "site-app",
     scope: {
       loadUser : function(){
-        this.attr('user', User.get({id: 1}));
+        this.attr('user', User.findOne({id: 1}));
       },
       loadAnotherUser : function(){
-        this.attr('user', User.get({id: 2}));
+        this.attr('user', User.findOne({id: 2}));
       },
       loadNonExistingUser : function(){
-        this.attr('user', User.get({id: 3}));
+        this.attr('user', User.findOne({id: 3}));
       }
     }
   });

--- a/model/promise/promise.html
+++ b/model/promise/promise.html
@@ -1,0 +1,90 @@
+
+<link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css"/>
+<style>
+  body {margin: 8px;}
+</style>
+<script type="text/javascript" src="../../lib/steal/steal.js"></script>
+<div id="demo">
+<div id="app"></div>
+
+<script type="text/mustache" id="app-template">
+
+<site-app>  
+  <a href="javascript://" can-click="loadUser">Load Existing User</a> | 
+  <a href="javascript://" can-click="loadAnotherUser">Load Another Existing User</a> | 
+  <a href="javascript://" can-click="loadNonExistingUser">Load Non Existing User</a>
+
+  <br>
+  
+  {{#if user.isPending}}
+    Loading user...
+  {{/if}}
+
+  {{#if user.isResolved}}
+    <div>
+      Username: {{user.username}}
+      <br>
+      Email: {{user.email}}
+    </div>
+  {{/if}}
+
+  {{#if user.isRejected}}
+    We were unable to load the user because {{user.reason.responseJSON.message}}
+  {{/if}}
+
+</site-app> 
+
+</script>
+</div>
+
+
+<script>DEMO_HTML = document.getElementById("demo").innerHTML</script>
+<script>
+  
+steal("can","can/util/fixture","can/model/promise",function(){
+  
+  can.fixture("GET /users/{id}", function(request, response){
+    if(request.data.id == "1"){
+      return {
+        id: 1,
+        username : 'Retro',
+        email: 'retro@example.com'
+      };
+    } else if(request.data.id == "2") {
+      return {
+        id: 2,
+        username : 'Neektza',
+        email: 'neektza@example.com'
+      };
+    } else {
+      response(404,"error",{message:"resource does not exist"});
+    }
+  });
+  can.fixture.delay = 1500;
+  
+  User = can.Model.extend({
+    findOne: "GET /users/{id}"
+  },{});
+  
+  can.Component.extend({
+    tag: "site-app",
+    scope: {
+      loadUser : function(){
+        this.attr('user', User.get({id: 1}));
+      },
+      loadAnotherUser : function(){
+        this.attr('user', User.get({id: 2}));
+      },
+      loadNonExistingUser : function(){
+        this.attr('user', User.get({id: 3}));
+      }
+    }
+  });
+  
+  $("#app").html(  can.view("app-template",{}))
+  
+});
+  
+  
+  
+</script>

--- a/model/promise/promise.js
+++ b/model/promise/promise.js
@@ -29,12 +29,12 @@ steal("can/model", 'can/compute', function (Model) {
 		if(!can.isDeferred(def)){
 			val = def;
 			def = new can.Deferred();
-			def.resolve(res);
+			def.resolve(val);
 		}
 
 		// Create status check functions.
 		can.each(defStatusFns, function (value, method) {
-			result[name] = wrapper[method] = function () {
+			result[name] = def[method] = function () {
 				return state() === value;
 			};
 		});
@@ -42,12 +42,12 @@ steal("can/model", 'can/compute', function (Model) {
 		// Proxy functions from the `result` object to the deferred object,
 		// to allow the `result` compute to behave like a deferred object.
 		can.each(defFns, function (name) {
-			result[name] = wrapper[name] = function () {
+			result[name] = function () {
 				return def[name].apply(def, arguments);
 			};
 		});
 
-		result(wrapper);
+		result(def);
 		state(def.state());
 
 		def.then(function(data){
@@ -58,9 +58,12 @@ steal("can/model", 'can/compute', function (Model) {
 			can.batch.stop();
 		}, function(reason){
 			can.batch.start();
-			result(can.extend(wrapper, {
-				reason: reason
-			}));
+			result({
+				reason : reason,
+				isPending : function(){ return false },
+				isResolved : function(){ return false },
+				isRejected : function(){ return true }
+			});
 			state(def.state());
 			can.batch.stop();
 		});

--- a/model/promise/promise.js
+++ b/model/promise/promise.js
@@ -32,7 +32,7 @@ steal("can/model", 'can/compute', function (Model) {
 
 		// Create status check functions.
 		can.each(defStatusFns, function (value, method) {
-			result[name] = def[method] = function () {
+			result[method] = def[method] = function () {
 				return state() === value;
 			};
 		});
@@ -85,6 +85,11 @@ steal("can/model", 'can/compute', function (Model) {
 				var res = old.apply(this, arguments),
 					def = can.isDeferred(res) ? res : new can.Deferred(),
 					self = this;
+
+				can.batch.start();
+				this._def.attr('state', def.state());
+				this._def.removeAttr('reason');
+				can.batch.stop();
 
 				def.then(function(){
 					can.batch.start();

--- a/model/promise/promise.js
+++ b/model/promise/promise.js
@@ -22,7 +22,7 @@ steal("can/model", 'can/compute', function () {
 		wrapFindOne(this);
 
 		return res;
-	}
+	};
 
 	var wrapFindOne = function(Model){
 		var oldFindOne = Model.findOne;

--- a/model/promise/promise.js
+++ b/model/promise/promise.js
@@ -1,0 +1,113 @@
+steal("can/model", 'can/compute', function (Model) {
+
+	var defStatusFns = {
+		isResolved: "resolved",
+		isPending: "pending",
+		isRejected: "rejected"
+	};
+
+	var defFns = [
+		"then",
+		"done",
+		"fail",
+		"always",
+		"promise"
+	];
+
+
+	can.Model.get = function(){
+		// Setup computes and call `findOne` to make the request.
+		var result = can.compute(),
+			state = can.compute(),
+			def = this.findOne.apply(this, arguments),
+			wrapper = {},
+			val;
+
+		// If `findOne` returned something that is not deferred,
+		// manually create deferred object and resolve it with the
+		// return value from the `findOne` function.
+		if(!can.isDeferred(def)){
+			val = def;
+			def = new can.Deferred();
+			def.resolve(res);
+		}
+
+		// Create status check functions.
+		can.each(defStatusFns, function (value, method) {
+			result[name] = wrapper[method] = function () {
+				return state() === value;
+			};
+		});
+
+		// Proxy functions from the `result` object to the deferred object,
+		// to allow the `result` compute to behave like a deferred object.
+		can.each(defFns, function (name) {
+			result[name] = wrapper[name] = function () {
+				return def[name].apply(def, arguments);
+			};
+		});
+
+		result(wrapper);
+		state(def.state());
+
+		def.then(function(data){
+			console.log(data)
+			can.batch.start();
+			result(data);
+			state(def.state());
+			can.batch.stop();
+		}, function(reason){
+			can.batch.start();
+			result(can.extend(wrapper, {
+				reason: reason
+			}));
+			state(def.state());
+			can.batch.stop();
+		});
+
+		return result;
+	};
+
+	// Add internal deferred state to the model. It is `resolved` by default
+	// because we can assume that if the instance exists, it is resolved, and
+	// there shouldn't be any difference in API based on from where does the
+	// instance come.
+	var oldSetup = can.Model.prototype.setup;
+
+	can.Model.prototype.setup = function(){
+		var res = oldSetup.apply(this, arguments);
+		this._defState = can.compute('resolved');
+		return res;
+	};
+
+	// Wrap `save` and `destroy` functions, and change deferred state
+	// based on the state of the request.
+	can.each(['save', 'destroy'], function(method){
+		var old = can.Model.prototype[method];
+
+		can.Model.prototype[method] = function(){
+			var res = old.apply(this, arguments),
+				def = can.isDeferred(res) ? res : new can.Deferred(),
+				self = this;
+
+			def.then(function(){
+				self._defState(def.state());
+			}, function(){
+				self._defState(def.state());
+			})
+
+			if(res !== def){
+				def.resolve(res);
+			}
+
+			return res;
+		}
+	});
+
+	// Add `isResolved`, `isPending` and `isRejected` to the model prototype.
+	can.each(defStatusFns, function(value, method){
+		can.Model.prototype[method] = function(){
+			return this._defState() === value;
+		}
+	});
+});

--- a/model/promise/promise_test.js
+++ b/model/promise/promise_test.js
@@ -17,8 +17,8 @@ steal("can/model/promise","can/compute", "can/util/fixture", "can/test", functio
 		var User = can.Model.extend({
 				findOne : "/users/{id}"
 			}, {}),
-			user = User.get({id: 1}),
-			missingUser = User.get({id: 'foo'});
+			user = User.findOne({id: 1}),
+			missingUser = User.findOne({id: 'foo'});
 
 		stop();
 		ok(!user.isResolved(), "User is not resolved");

--- a/model/promise/promise_test.js
+++ b/model/promise/promise_test.js
@@ -1,0 +1,3 @@
+steal("can/model/promise","can/compute","can/test", function () {
+
+});

--- a/model/promise/promise_test.js
+++ b/model/promise/promise_test.js
@@ -1,3 +1,80 @@
-steal("can/model/promise","can/compute","can/test", function () {
+steal("can/model/promise","can/compute", "can/util/fixture", "can/test", function () {
 
+	module("can/list/promise");
+
+	test("Model.get returns a compute that behaves like deferred", function(){
+		can.fixture('GET /users/{id}', function(request, response){
+			if(request.data.id === 1){
+				return {
+					id: 1,
+					name : 'retro'
+				}
+			} else {
+				response(404, "error", {message:"resource does not exist"});
+			}
+			
+		});
+
+		var User = can.Model.extend({
+				findOne : "/users/{id}"
+			}, {}),
+			user = User.get({id: 1}),
+			missingUser = User.get({id: 'foo'});
+
+		stop();
+		ok(!user.isResolved(), "User is not resolved");
+		ok(!user.isResolved(), "User is not rejected");
+		ok(user.isPending(), "User is pending");
+
+		user.then(function(data){
+			ok(user.isResolved() && user().isResolved(), 'User is resolved')
+			equal(data.attr('id'), 1, "User is resolved with the correct data");
+		});
+
+		missingUser.fail(function(){
+			ok(missingUser.isRejected() && missingUser().isRejected(), 'Missing user is rejected');
+			equal(missingUser().reason().responseJSON.message, 'resource does not exist', 'Missing user is rejected with the correct error');
+			start();
+		});
+	});
+
+	test("Model is aware of it's internal deferred state", function(){
+		can.fixture("POST /users", function(req){
+			return can.extend({id: 1, isSaved : true}, req.data);
+		})
+
+		can.fixture("DELETE /users/{id}", function(req, response){
+			response(406, "error", {message:"resource can't be destroyed"});
+		})
+
+		var User = can.Model.extend({
+				create : "POST /users",
+				destroy : "DELETE /users/{id}"
+			}, {}),
+			user = new User,
+			def;
+
+		stop();
+
+		ok(user.isResolved(), 'User is in resolved state by default');
+
+
+		def = user.save();
+
+		ok(user.isPending(), 'Saving user is putting it in the pending state');
+
+		def.then(function(){
+			ok(user.isResolved(), 'After saving user is in resolved state');
+			def = user.destroy();
+			def.fail(function(){
+				ok(user.isRejected(), 'Destroying an user is rejected');
+				equal(user.reason().responseJSON.message,  "resource can't be destroyed", 'Rejecting returns correct reason');
+				def = user.save();
+				ok(!user.reason(),  'Saving model clears the reason');
+				def.abort();
+				start();
+			})
+		})
+
+	})
 });

--- a/model/promise/promise_test.js
+++ b/model/promise/promise_test.js
@@ -8,11 +8,10 @@ steal("can/model/promise","can/compute", "can/util/fixture", "can/test", functio
 				return {
 					id: 1,
 					name : 'retro'
-				}
+				};
 			} else {
 				response(404, "error", {message:"resource does not exist"});
 			}
-			
 		});
 
 		var User = can.Model.extend({
@@ -27,7 +26,7 @@ steal("can/model/promise","can/compute", "can/util/fixture", "can/test", functio
 		ok(user.isPending(), "User is pending");
 
 		user.then(function(data){
-			ok(user.isResolved() && user().isResolved(), 'User is resolved')
+			ok(user.isResolved() && user().isResolved(), 'User is resolved');
 			equal(data.attr('id'), 1, "User is resolved with the correct data");
 		});
 
@@ -41,17 +40,17 @@ steal("can/model/promise","can/compute", "can/util/fixture", "can/test", functio
 	test("Model is aware of it's internal deferred state", function(){
 		can.fixture("POST /users", function(req){
 			return can.extend({id: 1, isSaved : true}, req.data);
-		})
+		});
 
 		can.fixture("DELETE /users/{id}", function(req, response){
 			response(406, "error", {message:"resource can't be destroyed"});
-		})
+		});
 
 		var User = can.Model.extend({
 				create : "POST /users",
 				destroy : "DELETE /users/{id}"
 			}, {}),
-			user = new User,
+			user = new User(),
 			def;
 
 		stop();
@@ -73,8 +72,8 @@ steal("can/model/promise","can/compute", "can/util/fixture", "can/test", functio
 				ok(!user.reason(),  'Saving model clears the reason');
 				def.abort();
 				start();
-			})
-		})
+			});
+		});
 
-	})
+	});
 });

--- a/model/promise/test.html
+++ b/model/promise/test.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <link rel="stylesheet" type="text/css" href="//code.jquery.com/qunit/qunit-1.14.0.css"/>
+</head>
+<body>
+<h1 id="qunit-header">can.Model promise Test Suite</h1>
+
+<h2 id="qunit-banner"></h2>
+
+<div id="qunit-testrunner-toolbar"></div>
+<h2 id="qunit-userAgent"></h2>
+<ol id="qunit-tests"></ol>
+<div id="qunit-test-area"></div>
+
+<script type="text/javascript" src="../../lib/steal/steal.js"></script>
+<script type="text/javascript" src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
+<script type="text/javascript">
+    if (typeof QUnit === 'undefined') {
+        document.write(unescape('%3Clink rel="stylesheet" type="text/css" href="../bower_components/qunit/qunit/qunit.css" /%3E'));
+        document.write(unescape('%3Cscript type="text/javascript" src="../bower_components/qunit/qunit/qunit.js" %3E%3C/script%3E'));
+    }
+
+    QUnit.config.autostart = false;
+  setTimeout(function(){
+    steal("can/model/promise/promise_test.js", function() {
+      can.dev.logLevel = 3;
+          QUnit.start();
+    });
+  },200);
+</script>
+</body>
+</html>

--- a/model/promise/test.html
+++ b/model/promise/test.html
@@ -23,7 +23,7 @@
 
     QUnit.config.autostart = false;
   setTimeout(function(){
-    steal("can/model/promise/promise_test.js", function() {
+    steal("can/model/promise", "can/model/model_test.js", "can/model/promise/promise_test.js", function() {
       can.dev.logLevel = 3;
           QUnit.start();
     });


### PR DESCRIPTION
This implements promise API for can.Model as mentioned in #951 . Docs are missing, but I'll add them if we agree on the implementation.

It adds the `.get` static function on the model which calls `.findOne` internally and returns a compute that holds the deferred object returned from the `.findOne` function. When this deferred is resolved or rejected compute is updated.

It also implements deferred state for the model instances which gets updated when `destroy` or `save` request is happening.

It has a demo similar to one in the `can/list/promise` plugin.