### PR TITLE
Mustache deferreds

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -2056,6 +2056,31 @@ steal('can/util',
 						console.log(expr, options.context);
 					}
 				}
+			},
+			'def' : function(deferred, opts){
+				var resolved = can.compute(),
+					rejected = can.compute(),
+					defState = can.compute(function(){
+						var rs = resolved(),
+							rj = rejected();
+
+						return {
+							isResolved: !!rs,
+							isRejected: !!rj,
+							isPending: !(rs || rj)
+						};
+					});
+
+				if(!can.isDeferred(deferred)){
+					deferred = (new can.Deferred()).resolve(deferred);
+				}
+
+				deferred.then(resolved, rejected);
+
+				return opts.fn(opts.scope.add(defState).add({
+					"@data": resolved,
+					"@error": rejected
+				}));
 			}
 			/**
 			 * @function can.mustache.helpers.elementCallback {{(el)->CODE}}

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -3795,4 +3795,58 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		var frag = can.mustache(tmpl)({ noData: true });
 		equal(frag.childNodes[0].innerHTML, 'no data', 'else with unless worked');
 	});
+
+	test("def helper - resolve deferred", function(){
+		var tmpl = '<div>{{#def user}}' +
+						'{{#if isPending}}PENDING{{/if}}' +
+						'{{#if isResolved}}{{@data.username}}{{/if}}' +
+					'{{/def}}</div>',
+			data = {
+				user: new can.Deferred()
+			},
+			frag = can.mustache(tmpl)(data);
+
+
+		equal(frag.childNodes[0].innerHTML, 'PENDING');
+
+		data.user.resolve({username : 'retro'});
+
+		equal(frag.childNodes[0].innerHTML, 'retro');
+
+	});
+
+	test("def helper - reject deferred", function(){
+		var tmpl = '<div>{{#def user}}' +
+						'{{#if isPending}}PENDING{{/if}}' +
+						'{{#if isRejected}}{{@error.reason}}{{/if}}' +
+					'{{/def}}</div>',
+			data = {
+				user: new can.Deferred()
+			},
+			frag = can.mustache(tmpl)(data);
+
+
+		equal(frag.childNodes[0].innerHTML, 'PENDING');
+
+		data.user.reject({reason : 'no user'});
+
+		equal(frag.childNodes[0].innerHTML, 'no user');
+
+	});
+
+	test("def helper - data that is not deferred will be treated like it is", function(){
+		var tmpl = '<div>{{#def user}}' +
+						'{{#if isPending}}PENDING{{/if}}' +
+						'{{#if isResolved}}{{@data.username}}{{/if}}' +
+					'{{/def}}</div>',
+			data = {
+				user: {
+					username : 'retro'
+				}
+			},
+			frag = can.mustache(tmpl)(data);
+
+		equal(frag.childNodes[0].innerHTML, 'retro');
+
+	});
 });

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -110,6 +110,31 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 				
 				can.data( can.$(el), attr, data || this.context );
 			};
+		},
+		'def' : function(deferred, opts){
+			var resolved = can.compute(),
+				rejected = can.compute(),
+				defState = can.compute(function(){
+					var rs = resolved(),
+						rj = rejected();
+
+					return {
+						isResolved: !!rs,
+						isRejected: !!rj,
+						isPending: !(rs || rj)
+					};
+				});
+
+			if(!can.isDeferred(deferred)){
+				deferred = (new can.Deferred()).resolve(deferred);
+			}
+
+			deferred.then(resolved, rejected);
+
+			return opts.fn(opts.scope.add(defState).add({
+				"@data": resolved,
+				"@error": rejected
+			}));
 		}
 	};
 	

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3479,4 +3479,55 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs",fu
 		data.attr('color', false);
 		equal(frag.childNodes[0].getAttribute('class'), 'red', 'else branch');
 	});
+
+	test("def helper - resolve deferred", function(){
+		var tmpl = '<div>{{#def user}}' +
+						'{{#if isPending}}PENDING{{/if}}' +
+						'{{#if isResolved}}{{@data.username}}{{/if}}' +
+					'{{/def}}</div>',
+			data = {
+				user: new can.Deferred()
+			},
+			frag = can.stache(tmpl)(data);
+
+
+		equal(frag.childNodes[0].innerHTML, 'PENDING');
+
+		data.user.resolve({username : 'retro'});
+
+		equal(frag.childNodes[0].innerHTML, 'retro');
+	});
+
+	test("def helper - reject deferred", function(){
+		var tmpl = '<div>{{#def user}}' +
+						'{{#if isPending}}PENDING{{/if}}' +
+						'{{#if isRejected}}{{@error.reason}}{{/if}}' +
+					'{{/def}}</div>',
+			data = {
+				user: new can.Deferred()
+			},
+			frag = can.stache(tmpl)(data);
+
+
+		equal(frag.childNodes[0].innerHTML, 'PENDING');
+
+		data.user.reject({reason : 'no user'});
+
+		equal(frag.childNodes[0].innerHTML, 'no user');
+	});
+
+	test("def helper - data that is not deferred will be treated like it is", function(){
+		var tmpl = '<div>{{#def user}}' +
+						'{{#if isPending}}PENDING{{/if}}' +
+						'{{#if isResolved}}{{@data.username}}{{/if}}' +
+					'{{/def}}</div>',
+			data = {
+				user: {
+					username : 'retro'
+				}
+			},
+			frag = can.stache(tmpl)(data);
+
+		equal(frag.childNodes[0].innerHTML, 'retro');
+	});
 });


### PR DESCRIPTION
Implements `def` helper that can handle deferreds in the template code. 

Sample use:

	{{#def Todo.findAll}}
		{{#if isResolved}}
			{{@data}}
				... iterate over the data
			{{/}}
		{{/if}}

		{{#if isRejected}}
			{{@error}}
				... print out the error
			{{/}}
		{{/if}}

		{{#if isPending}}
			still pending
		{{/if}}
	{{/def}}

I prefer this syntax to anything other mentioned in the #179 because it's more explicit and it's immediately clear what's happening.

`def` helper can also handle non-deferred values in which case it will treat it as resolved.

@justinbmeyer any comments?