### PR TITLE
Fixes #1069 - can.Component now defaults to lexical semantics for light dom

### DIFF
--- a/component/component.md
+++ b/component/component.md
@@ -263,6 +263,50 @@ only renders friendly messages:
       }
     });
 
+### LeakScope
+
+A component's [can.Component::leakScope leakScope] option controls whether
+the surrounding template where the component is used can directly share
+scope with the component's internal scope. This option defaults to `true`,
+which means `<content>` is able to access internal scope variables on the
+component, and the component will be able to use outside variables when
+used on a page.
+
+For example, if the following component is defined:
+
+    can.Component.extend({
+        tag: "hello-world",
+        leakScope: true, // the default value
+        template: "{{greeting}} <content></content>{{exclamation}}",
+        scope: { greeting: "Hello" }
+    })
+
+And used like so:
+
+    <hello-world>{{greeting}}</hello-world>
+
+With the following data in the surrounding scope:
+
+    { greeting: "World", exclamation: "!" }
+
+Will render the following if `leakScope` is true:
+
+    <hello-world>Hello Hello!</hello-world>
+
+But if `leakScope` is false:
+
+    <hello-world>Hello World</hello-world>
+
+Because when the scope isn't leaked, the internal `template` for the
+component does not see the surrounding binding for `exclamation` or
+`greeting`, and simply uses its internal `scope` to render its
+template. This also affects where the `{{greeting}}` will be looked up, in
+the light dom.
+
+Using the `leakScope: false` option is useful for hiding and protecting
+internal details of `can.Component`, potentially preventing accidental
+clashes.
+
 ## Differences between components in can.mustache and can.stache
 
 A [can.mustache] template passes values from the scope to a [can.Component]

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -189,6 +189,55 @@ steal("can/component", "can/view/stache", function () {
 		can.remove(can.$("#qunit-test-area>*"));
 	});
 
+	test("lexical scoping", function() {
+		can.Component.extend({
+			tag: "hello-world",
+			leakScope: false,
+			template: can.view.mustache("{{greeting}} <content>World</content>{{exclamation}}"),
+			scope: {greeting: "Hello"}
+		});
+		var template = can.view.mustache("<hello-world>{{greeting}}</hello-world>");
+		can.append(can.$("#qunit-test-area"), template({
+			greeting: "World",
+			exclamation: "!"
+		}));
+		var hello = can.$("#qunit-test-area hello-world");
+		equal(hello[0].innerHTML.trim(), "Hello World");
+		can.remove(can.$("#qunit-test-area > *"));
+		
+		can.Component.extend({
+			tag: "hello-world-no-template",
+			leakScope: false,
+			scope: {greeting: "Hello"}
+		});
+		template = can.view.mustache("<hello-world-no-template>{{greeting}}</hello-world-no-template>");
+		can.append(can.$("#qunit-test-area"), template({
+			greeting: "World",
+			exclamation: "!"
+		}));
+		hello = can.$("#qunit-test-area hello-world-no-template");
+		equal(hello[0].innerHTML.trim(), "Hello",
+			  "If no template is provided to can.Component, treat <content> bindings as dynamic.");
+		can.remove(can.$("#qunit-test-area > *"));
+	});
+
+	test("dynamic scoping", function() {
+		can.Component.extend({
+			tag: "hello-world",
+			leakScope: true,
+			template: can.view.mustache("{{greeting}} <content>World</content>{{exclamation}}"),
+			scope: {greeting: "Hello"}
+		});
+		var template = can.view.mustache("<hello-world>{{greeting}}</hello-world>");
+		can.append(can.$("#qunit-test-area"), template({
+			greeting: "World",
+			exclamation: "!"
+		}));
+		var hello = can.$("#qunit-test-area hello-world");
+		equal(hello[0].innerHTML.trim(), "Hello Hello!");
+		can.remove(can.$("#qunit-test-area > *"));
+	});
+
 	test("treecombo", function () {
 
 		can.Component.extend({
@@ -728,10 +777,11 @@ steal("can/component", "can/view/stache", function () {
 
 		can.Component.extend({
 			tag: 'my-scope',
+			template: "{{name}}}",
 			scope: me
 		});
 
-		var template = can.view.mustache('<my-scope>{{name}}</my-scope>');
+		var template = can.view.mustache('<my-scope></my-scope>');
 		equal(template()
 			.childNodes[0].innerHTML, "Justin");
 
@@ -1177,10 +1227,11 @@ steal("can/component", "can/view/stache", function () {
 		var Constructed = can.Construct.extend({foo:"bar"},{});
 		
 		can.Component.extend({
-			tag: "con-struct"
+			tag: "con-struct",
+			template: "{{con.foo}}"
 		});
 		
-		var stached = can.stache("<con-struct con='{Constructed}'>{{con.foo}}</con-struct>");
+		var stached = can.stache("<con-struct con='{Constructed}'></con-struct>");
 		
 		var res = stached({
 			Constructed: Constructed
@@ -1247,10 +1298,10 @@ steal("can/component", "can/view/stache", function () {
 	});
 	
 	test("hyphen-less tag names", function () {
-		var template = can.view.mustache('<span></span><foobar>{{name}}</foobar>');
+		var template = can.view.mustache('<span></span><foobar></foobar>');
 		can.Component.extend({
 			tag: "foobar",
-			template: "<div><content/></div>",
+			template: "<div>{{name}}</div>",
 			scope: {
 				name: "Brian"
 			}
@@ -1285,5 +1336,4 @@ steal("can/component", "can/view/stache", function () {
 
 		equal(frag.childNodes[0].innerHTML, '', 'child component is removed');
 	});
-
 });


### PR DESCRIPTION
Here's a first pass at implementing the semantics described in #1069