### PR TITLE
Fixes #881 - Export component prototype methods on the HTMLElement

### DIFF
--- a/component/component.md
+++ b/component/component.md
@@ -79,9 +79,13 @@ with the methods and properties of how your component behaves:
         message: "Hello There!"
       },
       events: {
-        click: function(){
-        	this.scope.attr("visible", !this.scope.attr("visible") );
+        click: function() {
+            this.element[0].toggle();
         }
+      },
+      toggle: function() {
+        var scope = $(this).scope();
+        return scope.attr("visible", !scope.attr("visible"));
       }
     });
 
@@ -262,6 +266,31 @@ only renders friendly messages:
         }
       }
     });
+
+### Additional methods
+
+Any other function properties added to the `can.Component` prototype will
+be treated as methods on the `HTMLElement` instance of the component
+itself. Note that this means the actual `HTMLElement`, not the `jQuery` (or
+other library) wrapped instance.
+
+
+    can.Component.extend({
+        tag: "methods-component",
+        template: "{{callValue}}",
+        scope: {callValue: "No value yet"}
+        callMeMaybe: function(val) {
+            this.scope.attr("callValue", val);
+            return "value was: "+val;
+        }
+    });
+
+Once the component is on the page, you will be able to do:
+
+    document.getElementsByTagName("methods-component")[0].callMeMaybe("Hi!");
+
+and it should return `"Hi!"`. You should also see the contents of the
+element change.
 
 ## Differences between components in can.mustache and can.stache
 

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1260,6 +1260,42 @@ steal("can/component", "can/view/stache", function () {
 
 	});
 
+	test("external component methods on the HTMLElement (#881)", function() {
+		can.Component.extend({
+			tag: "methods-component",
+			template: can.stache("{{callValue}}"),
+			scope: function() { return new can.Map({callValue: null}); },
+			callMeMaybe: function(val) {
+				this.scope.attr("callValue", val);
+				return "value was: "+val;
+			},
+			notAFunction: 5
+		});
+		can.append(can.$("#qunit-test-area"),
+				   can.stache("<methods-component></methods-component>"+
+							  "<methods-component></methods-component>")({}));
+
+		var components = document.getElementsByTagName("methods-component");
+		var el = components[0];
+		equal(el.innerHTML, "");
+		equal(typeof el.callMeMaybe, "function", "callMeMaybe present on the HTMLElement");
+		equal(el.callMeMaybe(10), "value was: 10",
+			  "Calling methods returns the function's value as expected.");
+		equal(el.innerHTML, "10");
+		equal(el.scope, can.data(can.$(el), "scope"), "Scope is exported directly");
+		equal(el.scope.attr("callValue"), 10);
+		equal(typeof el.notAFunction, "undefined",
+			  "Non-functions are not exported.");
+		equal(typeof el.tag, "undefined",
+			  "`tag` property is not exported.");
+		equal(typeof el.template, "undefined",
+			  "`template` property is not exported.");
+		equal(el.callMeMaybe, components[1].callMeMaybe,
+			  "Function references are shared between components.");
+		ok(el.scope !== components[1].scope,
+		   "But the scopes are still different");
+	});
+
 	test('nested component within an #if is not live bound(#1025)', function() {
 		can.Component.extend({
 			tag: 'parent-component',


### PR DESCRIPTION
Here's a first pass. I kinda like the way this API feels -- it's important here that we're pretending the `can.Component` prototype is the `HTMLElement` prototype (with a couple of exceptions for other options).

See the test case for other/various little details about how this works.