### PR TITLE
Sorting a List doesn't update in a template correctly

### DIFF
--- a/list/list.js
+++ b/list/list.js
@@ -718,7 +718,7 @@ steal("can/util", "can/map", "can/map/bubble.js",function (can, Map, bubble) {
 				// Call the original method.
 				res = orig.apply(this, args);
 
-				if (!this.comparator || args.length) {
+				if (!this.comparator && args.length) {
 
 					this._triggerChange("" + len, "add", args, undefined);
 				}

--- a/map/sort/sort.js
+++ b/map/sort/sort.js
@@ -143,7 +143,7 @@ steal('can/util', 'can/list', function (can) {
 		});
 	//- override changes for sorting
 	proto._changes = function (ev, attr, how, newVal, oldVal) {
-		if (this.comparator && /^\d+./.test(attr)) {
+		if (this.comparator && /^\d/.test(attr)) {
 			// get the index
 			var index = +/^\d+/.exec(attr)[0],
 				// and item

--- a/map/sort/sort.js
+++ b/map/sort/sort.js
@@ -1,4 +1,4 @@
-steal('can/util', 'can/list', function (can) {
+steal('can/util', 'can/list', 'can/map/bubble.js', function (can) {
 
 	// Change bubble rule to bubble on change if their is a comparator
 	var oldBubbleRule = can.List._bubbleRule;
@@ -124,21 +124,22 @@ steal('can/util', 'can/list', function (can) {
 			var proto = can.List.prototype,
 				old = proto[name];
 			proto[name] = function () {
-				// get the items being added
-				var args = getArgs(arguments),
-					// where we are going to add items
-					len = where ? this.length : 0;
-				// call the original method
-				var res = old.apply(this, arguments);
-				// cause the change where the args are:
-				// len - where the additions happened
-				// add - items added
-				// args - the items added
-				// undefined - the old value
-				if (this.comparator && args.length) {
-					this._triggerChange('' + len, 'add', args, undefined);
+				if (this.comparator && arguments.length) {
+					// get the items being added
+					var args = getArgs(arguments);
+					var i = args.length;
+					while (i--) {
+						// Go through and convert anything to an `map` that needs to be converted.
+						var val = can.bubble.set(this, i, this.__type(args[i], i) );
+						// Insert this item at its sorted position.
+						var sortedIndex = this.sortedIndex(val);
+						this.splice(sortedIndex, 0, val);
+					}
+					return this;
+				} else {
+					// call the original method
+					return old.apply(this, arguments);
 				}
-				return res;
 			};
 		});
 	//- override changes for sorting

--- a/map/sort/sort.js
+++ b/map/sort/sort.js
@@ -63,8 +63,13 @@ steal('can/util', 'can/list', function (can) {
 				] : [method];
 			if (!silent) {
 				can.trigger(this, 'reset');
+				var clone = this.splice(0, this.length);
+				clone.sort.apply(clone, args);
+				return this.splice.apply(this, [0, 0].concat(clone));
 			}
-			return Array.prototype.sort.apply(this, args);
+			else {
+				return Array.prototype.sort.apply(this, args);
+			}
 		}
 	});
 	// create push, pop, shift, and unshift

--- a/map/sort/sort.js
+++ b/map/sort/sort.js
@@ -56,8 +56,8 @@ steal('can/util', 'can/list', function (can) {
 				args = comparator ? [
 
 					function (a, b) {
-						a = typeof a[comparator] === 'function' ? a[comparator]() : a[comparator];
-						b = typeof b[comparator] === 'function' ? b[comparator]() : b[comparator];
+						a = typeof a[comparator] === 'function' ? a[comparator]() : a.attr(comparator);
+						b = typeof b[comparator] === 'function' ? b[comparator]() : b.attr(comparator);
 						return a === b ? 0 : a < b ? -1 : 1;
 					}
 				] : [method];

--- a/map/sort/sort.js
+++ b/map/sort/sort.js
@@ -136,8 +136,6 @@ steal('can/util', 'can/list', function (can) {
 				// args - the items added
 				// undefined - the old value
 				if (this.comparator && args.length) {
-					this.sort(null, true);
-					can.batch.trigger(this, 'reset', [args]);
 					this._triggerChange('' + len, 'add', args, undefined);
 				}
 				return res;

--- a/map/sort/sort_test.js
+++ b/map/sort/sort_test.js
@@ -34,12 +34,11 @@ steal("can/map/sort", "can/test", "can/view/mustache", function () {
 			equal(items[0].name, 'Alexis');
 			equal(oldPos, 0, 'put in right spot');
 		});
-		list.bind('add', function (ev, items, newLength) {
+		list.bind('add', function (ev, items, pos) {
 			ok(true, 'add called');
 			equal(items.length, 1);
 			equal(items[0].name, 'Alexis');
-			// .push returns the new length not the current position
-			equal(newLength, 4, 'got new length');
+			equal(pos, 0, 'got sorted position');
 		});
 		list.push({
 			name: 'Alexis'

--- a/map/sort/sort_test.js
+++ b/map/sort/sort_test.js
@@ -125,4 +125,68 @@ steal("can/map/sort", "can/test", "can/view/mustache", function () {
 		equal(el.getElementsByTagName('li')
 			.length, 2, 'Live binding rendered second li');
 	});
+
+	test('live binding with comparator and {{#key}}', function () {
+		var renderer = can.view.mustache('<ul>{{#items}}<li>{{text}}</li>{{/items}}</ul>'),
+			el = document.createElement('div'),
+			items = new can.List([{
+				text: 'CCC'
+			}, {
+				text: 'BBB'
+			}]);
+		el.appendChild(renderer({
+			items: items
+		}));
+		equal(el.getElementsByTagName('li')[0].innerHTML, 'CCC',
+			'Unsorted list, 1st item');
+		equal(el.getElementsByTagName('li')[1].innerHTML, 'BBB',
+			'Unsorted list, 2nd item');
+
+		items.comparator = 'text';
+		items.sort();
+		equal(el.getElementsByTagName('li')[0].innerHTML, 'BBB',
+			'Sorted list, 1st item');
+		equal(el.getElementsByTagName('li')[1].innerHTML, 'CCC',
+			'Sorted list, 2nd item');
+
+		items.push({
+			text: 'AAA'
+		});
+		equal(el.getElementsByTagName('li')[0].innerHTML, 'AAA',
+			'Push to sorted list, 1st item');
+		equal(el.getElementsByTagName('li').length, 3,
+			'Push to sorted list, correct length');
+	});
+
+	test('live binding with comparator and {{#each key}}', function () {
+		var renderer = can.view.mustache('<ul>{{#each items}}<li>{{text}}</li>{{/each}}</ul>'),
+			el = document.createElement('div'),
+			items = new can.List([{
+				text: 'CCC'
+			}, {
+				text: 'BBB'
+			}]);
+		el.appendChild(renderer({
+			items: items
+		}));
+		equal(el.getElementsByTagName('li')[0].innerHTML, 'CCC',
+			'Unsorted list, 1st item');
+		equal(el.getElementsByTagName('li')[1].innerHTML, 'BBB',
+			'Unsorted list, 2nd item');
+
+		items.comparator = 'text';
+		items.sort();
+		equal(el.getElementsByTagName('li')[0].innerHTML, 'BBB',
+			'Sorted list, 1st item');
+		equal(el.getElementsByTagName('li')[1].innerHTML, 'CCC',
+			'Sorted list, 2nd item');
+
+		items.push({
+			text: 'AAA'
+		});
+		equal(el.getElementsByTagName('li')[0].innerHTML, 'AAA',
+			'Push to sorted list, 1st item');
+		equal(el.getElementsByTagName('li').length, 3,
+			'Push to sorted list, correct length');
+	});
 });

--- a/map/sort/sort_test.js
+++ b/map/sort/sort_test.js
@@ -1,7 +1,7 @@
 steal("can/map/sort", "can/test", "can/view/mustache", function () {
 	module('can/map/sort');
 
-	test('list events', 16, function () {
+	test('list events', 12, function () {
 		var list = new can.List([{
 			name: 'Justin'
 		}, {

--- a/map/sort/sort_test.js
+++ b/map/sort/sort_test.js
@@ -49,6 +49,39 @@ steal("can/map/sort", "can/test", "can/view/mustache", function () {
 		list[0].attr('name', 'Zed');
 	});
 
+
+	test('sort() events', 14, function () {
+		var list = new can.List([{
+			name: 'Justin'
+		}, {
+			name: 'Brian'
+		}, {
+			name: 'Austin'
+		}, {
+			name: 'Mihael'
+		}]);
+		list.bind('remove', function (ev, items, oldPos) {
+			ok(true, 'remove called');
+			equal(items.length, 4, 'remove all elements');
+			equal(items[0].name, 'Justin', 'remove elements in old order');
+		});
+		list.bind('add', function (ev, items) {
+			ok(true, 'add called');
+			equal(items.length, 4, 'add items correct length');
+			equal(items[0].name, 'Austin', 'add items in sorted order (1/4)');
+			equal(items[1].name, 'Brian', 'add items in sorted order (2/4)');
+			equal(items[2].name, 'Justin', 'add items in sorted order (3/4)');
+			equal(items[3].name, 'Mihael', 'add items in sorted order (4/4)');
+			equal(list.length, 4, 'list correct length');
+			equal(list[0].name, 'Austin', 'list in sorted order (1/4)');
+			equal(list[1].name, 'Brian', 'list in sorted order (2/4)');
+			equal(list[2].name, 'Justin', 'list in sorted order (3/4)');
+			equal(list[3].name, 'Mihael', 'list in sorted order (4/4)');
+		});
+		list.comparator = 'name';
+		list.sort();
+	});
+
 	test('list sort with func', 1, function () {
 		var list = new can.List([{
 			priority: 4,


### PR DESCRIPTION
I'm trying to use `.comparator` and `.sort()` as described in [can.Map.prototype.sort](http://canjs.com/docs/can.List.prototype.sort.html) to change the sorting of a can.List that is bound in a Mustache template.

The can.List gets correctly sorted, but there appear to be a few bugs that prevent the template from reflecting the sorted data correctly. 

Please refer to this [JSFiddle](http://jsfiddle.net/qYdwR/1627/):

* Calling `list.sort()` won't update the rendered template at all.
* But calling `can.trigger(list, 'length')` or `list.push(newItem)` WILL force the update, but only for `{{#key}}...{{/key}}` syntax. It's not the worst workaround, but I prefer to use `{{#each}}` because that provides `{{@index}}`.
* The `{{#each}}` syntax will never show list sorted, even after adding items to it.

  * (Another weird thing is, in this case, adding an item will render the new item twice.)

I've added tests that cover all of these issues.
