### PR TITLE
Make can/util/fixture work with new Steal

### DIFF
--- a/util/fixture/fixture.js
+++ b/util/fixture/fixture.js
@@ -12,13 +12,9 @@ steal('can/util', 'can/util/string', 'can/util/object', function (can) {
 	// Get the URL from old Steal root, new Steal config or can.fixture.rootUrl
 	var getUrl = function (url) {
 		if (typeof steal !== 'undefined') {
-			if (can.isFunction(steal.config)) {
-				return steal.config()
-					.root.mapJoin(url)
-					.toString();
-			}
-			return steal.root.join(url)
-				.toString();
+			var base = steal.config("baseUrl");
+			var joined = steal.joinURIs(base, url);
+			return joined;
 		}
 		return (can.fixture.rootUrl || '') + url;
 	};


### PR DESCRIPTION
This makes can/util/fixture work with the new Steal by replacing a call to the join Steal URI `mapJoin` with the new  `steal.joinURIs`.