### PR TITLE
Prevent empty routes from firing twice after can.route.ready

### DIFF
--- a/route/route.js
+++ b/route/route.js
@@ -652,7 +652,7 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 		if (!changingData || hash !== lastHash) {
 			can.batch.start();
 			for(var attr in oldParams){
-				if(!curParams[attr]){
+				if(curParams[attr] === undefined){
 					can.route.removeAttr(attr);
 				}
 			}

--- a/route/route_test.js
+++ b/route/route_test.js
@@ -473,13 +473,12 @@ steal("can/route", "can/test", function () {
 			iframe.src = can.test.path("route/testing.html?1");
 			testarea.appendChild(iframe);
 		});
-		
+
 		test("initial route fires twice", function () {
 			stop();
 			expect(1);
-			var testarea = document.getElementById('qunit-test-area');
 			window.routeTestReady = function (iCanRoute, loc) {
-				iCanRoute("", {})
+				iCanRoute("", {});
 				iCanRoute.bind('change', function(){
 					ok(true, 'change triggered once')
 					start();

--- a/route/route_test.js
+++ b/route/route_test.js
@@ -473,6 +473,23 @@ steal("can/route", "can/test", function () {
 			iframe.src = can.test.path("route/testing.html?1");
 			testarea.appendChild(iframe);
 		});
+		
+		test("initial route fires twice", function () {
+			stop();
+			expect(1);
+			var testarea = document.getElementById('qunit-test-area');
+			window.routeTestReady = function (iCanRoute, loc) {
+				iCanRoute("", {})
+				iCanRoute.bind('change', function(){
+					ok(true, 'change triggered once')
+					start();
+				});
+				iCanRoute.ready();
+			}
+			var iframe = document.createElement('iframe');
+			iframe.src = can.test.path("route/testing.html?5");
+			can.$("#qunit-test-area")[0].appendChild(iframe);
+		});
 
 		test("removing things from the hash", function () {
 			stop();


### PR DESCRIPTION
Addresses #1185 with a test and a fix.

The problem was a check to see if a value that used to be there was no longer there, and calls removeAttr on that property. This check was lazy and checked for falsiness rather than the true absence of a property, so it was trying to remove a property on the "route" property, which in the case of an empty route, is an empty string, and thus falsey.