### PR TITLE
can.compute placed on a can.Map should not be readonly

### DIFF
--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -325,7 +325,7 @@ steal("can/compute", "can/test", "can/map", function () {
 		equal(result.value, "Justin", "The correct value is found.");
 	});
 
-    test("can.compute placed on a can.Map shoud not be readonly", function(){
+    test("can.compute placed on a can.Map should not be readonly", function(){
 
         var MockViewModel = can.Map.extend({
             saveFailed: can.compute(false),

--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -324,5 +324,29 @@ steal("can/compute", "can/test", "can/map", function () {
 		var result = can.compute.read(parent, reads);
 		equal(result.value, "Justin", "The correct value is found.");
 	});
+
+    test("can.compute placed on a can.Map shoud not be readonly", function(){
+
+        var MockViewModel = can.Map.extend({
+            saveFailed: can.compute(false),
+            doSave: function(){
+                // Pretend that the save failed.
+                this.saveFailed(true);
+            }
+        });
+
+        var mockVMInstance = new MockViewModel();
+        // We expect that the inital value of the compute will be false.
+        // And we are correct.
+        equal(mockVMInstance.saveFailed(), false);
+
+        // We save and it doesnt' work.
+        mockVMInstance.doSave();
+
+        // We expect that the compute which manages the failed state
+        // would be true now. But we're wrong.
+        equal(mockVMInstance.saveFailed(), true);
+
+    });
 	
 });


### PR DESCRIPTION
This is a failing test to go with the bug report by the same name.

When a compute is added to a base can.Map.extend the compute becomes read only.