### PR TITLE
Making constructor name visible in debug builds and development mode

### DIFF
--- a/construct/construct.html
+++ b/construct/construct.html
@@ -71,6 +71,7 @@
 
 			var person = new Bitovi.Person();
 			console.log(person.constructor.shortName); // -> 'Person'
+			console.log(person.constructor.name); // -> 'Person'
 		});
 	</script>
     </body>

--- a/construct/construct_test.js
+++ b/construct/construct_test.js
@@ -70,6 +70,12 @@ steal('can/construct', function () {
 		can.Construct('Todo', {}, {});
 		ok(Foo.Bar === fb, 'returns class');
 		equal(fb.shortName, 'Bar', 'short name is right');
+		//!steal-remove-start
+		if (can.dev) {
+			equal(fb.name, 'Bar', 'short name is right');
+		}
+		//!steal-remove-end
+
 		equal(fb.fullName, 'Foo.Bar', 'fullName is right');
 	});
 	test('setups', function () {


### PR DESCRIPTION
This is a cleaned up version of PR #1009 which fixes #1000

The solution is the exact same (eval), but wrapped with `steal-remove` tags so it is only done in dev builds or development mode (when using steal).