### PR TITLE
can-EVENT handlers that aren't visible in the page

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -181,7 +181,14 @@ steal("can/util", "can/view/callbacks", "can/control", function (can) {
 			handler = function (ev) {
 				// The attribute value, representing the name of the method to call (i.e. can-submit="foo" foo is the 
 				// name of the method)
-				var attr = removeCurly( el.getAttribute(attributeName) ),
+				var attrVal = el.getAttribute(attributeName);
+				// if the attribute is not present currently, don't run the event handler, but don't unbind,  
+				// since it might just be temporarily hidden
+				if(!attrVal){
+					return false;
+				}
+
+				var attr = removeCurly( attrVal ),
 					scopeData = data.scope.read(attr, {
 						returnObserveMethods: true,
 						isArgument: true

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -561,17 +561,58 @@ steal("can/view/bindings", "can/map", "can/test", "can/view/stache", function (s
 								'{{#if thing}}\n<div />{{/if}}'+
 								'<span>{{name}}</span>'+
 							 '</a>';
-		//var mustacheRenderer = can.mustache(templateString);
 		var stacheRenderer = can.stache(templateString);
 		
 		var obj = new can.Map({thing: 'stuff'});
 		
 		
-		//mustacheRenderer(obj);
-		//ok(true, 'mustache worked without errors');
 		stacheRenderer(obj);
 		ok(true, 'stache worked without errors');
 		
+	});
+
+	test("can-event throws an error when inside #if block (#1182)", function(){
+		var flag = can.compute(false),
+			clickHandlerCount = 0;
+		var frag = can.view.mustache("<div {{#if flag}}can-click='foo'{{/if}}>Click</div>")({
+			flag: flag,
+			foo: function () {
+				clickHandlerCount++;
+			}
+		});
+		var trig = function(){
+			var div = can.$('#qunit-test-area')[0].getElementsByTagName('div')[0];
+			can.trigger(div, {
+				type: "click"
+			});
+		};
+		can.append(can.$('#qunit-test-area'), frag);
+		trig();
+		equal(clickHandlerCount, 0, "click handler not called");
+	});
+
+	test("can-EVENT removed in live bindings doesn't unbind (#1112)", function(){
+		var flag = can.compute(true),
+			clickHandlerCount = 0;
+		var frag = can.view.mustache("<div {{#if flag}}can-click='foo'{{/if}}>Click</div>")({
+			flag: flag,
+			foo: function () {
+				clickHandlerCount++;
+			}
+		});
+		var trig = function(){
+			var div = can.$('#qunit-test-area')[0].getElementsByTagName('div')[0];
+			can.trigger(div, {
+				type: "click"
+			});
+		};
+		can.append(can.$('#qunit-test-area'), frag);
+		trig();
+		flag(false);
+		trig();
+		flag(true);
+		trig();
+		equal(clickHandlerCount, 2, "click handler called twice");
 	});
 
 


### PR DESCRIPTION
fixes #1182 and fixes #1112

Prevents the hidden event handler from running if its not actually in the page.