### PR TITLE
Get travis to run test suites in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,10 @@ language: node_js
 node_js: 0.10
 before_script: node_modules/.bin/bower install
 script: npm test
+env:
+  - TEST_SUITE=steal
+  - TEST_SUITE=dist
+  - TEST_SUITE=dev
+  - TEST_SUITE=amd
+  - TEST_SUITE=compatibility
+  - TEST_SUITE=individuals


### PR DESCRIPTION
Implements parallel test runs by spinning off a Travis VM for each build which improves the CI runtime from ~20 minutes to ~5.