### PR TITLE
can.stache import support

### DIFF
--- a/view/stache/system.js
+++ b/view/stache/system.js
@@ -1,4 +1,4 @@
-steal("can/view/stache", function(stache){
+steal("can/view/stache", "can/view/scope", function(stache, Scope){
 
 	var escMap = {
 		'\n': "\\n",
@@ -18,12 +18,80 @@ steal("can/view/stache", function(stache){
 			});
 	};
 
+	/**
+	 * Finds multiple patterns of dependencies and turns them into static
+	 * dependencies of the .stache module. All syntaxes are converted to a
+	 * single `{{@import name parentName=parentName
+	 * parentAddress=parentAddress isPartial=isPartial}}` syntax that will
+	 * by dynamically handled by the `@import` helper.
+	 *
+	 * Returns an object with an array of static dependencies in `deps` and
+	 * the new, transformed source in `source`.
+	 */
+	function scanDependencies(string) {
+		// TODO - it would be nice to have a real parser preprocess the
+		// template as proper html and extracts these (and the {{@import
+		// ...}} tags) more correctly than this regex mess does. For now,
+		// though, hack it!
+		var re = new RegExp("(?:"+([
+			// * {{>(this right here)}}
+			/{{>\s*([^{}]+)\s*}}/.source,
+			// * {{@import "(this right here)"}}
+			/{{\s*@import\s+["']([^{}]+)['"]\s*}}/.source,
+			// * <link rel="import" href="(this one)">
+			/<\s*link\s*rel=['"]?import['"]?\s*href=['"]?([^'">]+)['"]?\s*\/?\s*>/.source,
+			// * <link href="(this one)" rel=import>
+			/<\s*link\s*href=['"]?([^"'>]+)['"]?\s*rel=['"]?import['"]?\s*\/?\s*>/.source
+		].join("|")) + ")", "g");
+		var deps = [],
+			nthDep = 2,
+			str = string.replace(re, function(match) {
+				var name;
+				for (var i = 1; i < arguments.length; i++) {
+					name = arguments[i];
+					if (name) { break; }
+				}
+				if (name) {
+					deps.push(name.trim());
+					return '{{___local_import___ "'+(nthDep++)+
+						'" isPartial="'+(~match.indexOf("{{>") ? "true" : "")+
+						'"}}';
+				} else {
+					return match;
+				}
+			});
+		return {deps: deps, source: str};
+	}
+
+	function loader(stache, Scope) {
+		var tpl = stache("TEMPLATE_GOES_HERE");
+		var deps = arguments;
+		return function(data, helpers) {
+			var help = helpers instanceof Scope ?
+					helpers :
+					new Scope(help||{});
+			return tpl(data, help.add({
+				___local_import___: function(nth, options) {
+					var mod = deps[+nth];
+					if (mod && mod.isPartial) {
+						return mod(options.scope, helpers);
+					} else {
+						return "";
+					}
+				}
+			}));
+		};
+	}
+
 	function translate(load) {
-
-		return "define(['can/view/stache/stache'],function(stache){" +
-			"return stache(\"" + esc(load.source) + "\")" +
-			"})";
-
+		var depsScanned = scanDependencies(load.source, load.name, load.address);
+		var deps = [
+			"can/view/stache/stache",
+			"can/view/scope/scope"
+		].concat(depsScanned.deps);
+		return "define("+JSON.stringify(deps)+","+
+			((""+loader).replace("TEMPLATE_GOES_HERE", esc(depsScanned.source)))+
+			");";
 	}
 
 	return {


### PR DESCRIPTION
This adds support for a variety of import syntaxes when using `steal` to load `stache` templates. See #1037 

The acceptable syntaxes are:

* `{{@import "modulename"}}`
* `<link rel="import" href="modulename">`

Additionally, this adds `steal`-based static resolution for partials, so the following is also supported, and will inline the template:

* `{{>modulename.stache!}}`

### Notes and Justification
The implementation is fairly rough right now, using plain old regexes to parse out and remove import information from the module string when the file is parsed by stache. Ideally, this would use our stache parser to yank these out more reliably, specially the `<link>` tags.

The biggest use case for this patch, aside from making partials more useful in applications that use `steal` as a loader, is to import `can.Component` and helper definitions right in the `stache` templates that use them without having to worry about load order of modules (and having these in the file that actually uses them).

### Example
```html
<link rel="import" href="can-tabs">
<link rel="import" href="can-tabs-tab">
{{@import "my_stache_helpers}}
<can-tabs>
  {{#each tabDefs}}
  <can-tab title="{{capitalize name}}">
    {{>./tab-boilerplate.stache!}}
    {{content}}
  </can-tab>
  {{/each}}
</can-tabs>
```