### PR TITLE
booleanAttr for components

### DIFF
--- a/map/define/define.js
+++ b/map/define/define.js
@@ -179,6 +179,13 @@ steal('can/util', 'can/observe', function (can) {
 			}
 			return true;
 		},
+		/**
+		 * Implements HTML-style boolean logic for attribute strings, where
+		 * any string, including "", is truthy.
+		 */
+		'htmlbool': function(val) {
+			return typeof val === "string" || !!val;
+		},
 		'*': function (val) {
 			return val;
 		},

--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -229,6 +229,7 @@ steal("can/map/define", "can/test", function () {
 				string: {type: 'string'},
 				number: {  type: 'number' },
 				'boolean': {  type: 'boolean' },
+				htmlbool: {  type: 'htmlbool' },
 				leaveAlone: {  type: '*' }
 			}
 		});
@@ -239,6 +240,7 @@ steal("can/map/define", "can/test", function () {
 			string: 5,
 			number: '5',
 			'boolean': 'false',
+			htmlbool: "",
 			leaveAlone: obj
 		});
 
@@ -249,6 +251,8 @@ steal("can/map/define", "can/test", function () {
 		equal(t.attr("number"), 5, "converted to number");
 
 		equal(t.attr("boolean"), false, "converted to boolean");
+
+		equal(t.attr("htmlbool"), true, "converted to htmlbool");
 
 		equal(t.attr("leaveAlone"), obj, "left as object");
 		t.attr({

--- a/map/define/doc/type.md
+++ b/map/define/doc/type.md
@@ -18,6 +18,9 @@ The `type` property specifies the type of the attribute.  The type can be specif
  - `"date"` - Converts the value to a date or `null if the date can not be converted.
  - `"number"` - Passes the value through `parseFloat`.
  - `"boolean"` - Converts falsey, `"false"` or `"0"` to `false` and everything else to true.
+ - `"htmlbool"` - Like `boolean`, but also converts empty strings to
+   `true`. Used, for example, when input is from component attributes like
+   `<can-tabs reverse/>`
  - `"*"` - Prevents the default type coersion of converting Objects to [can.Map]s and Arrays to [can.List]s.
 
 ### Basic Example


### PR DESCRIPTION
Components that want to use HTML-style booleans are currently forced to write this function manually. I think this is valuable enough to can.Component users that it's good to have built-in to the define plugin.