### PR TITLE
can.Component now supports lexical semantics for <content>

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -98,6 +98,12 @@ steal("can/util", "can/view/callbacks","can/control", "can/observe", "can/view/m
 				// Setup values passed to component
 				var initialScopeData = {},
 					component = this,
+					// If a template is not provided, we fall back to
+					// dynamic scoping regardless of settings.
+					lexicalContent = ((typeof this.leakScope === "undefined" ?
+									   false :
+									   !this.leakScope) &&
+									  this.template),
 					twoWayBindings = {},
 					// what scope property is currently updating
 					scopePropertyUpdating,
@@ -230,7 +236,9 @@ steal("can/util", "can/view/callbacks","can/control", "can/observe", "can/view/m
 				can.data(can.$(el), "scope", this.scope);
 
 				// Create a real Scope object out of the scope property
-				var renderedScope = hookupOptions.scope.add(this.scope),
+				var renderedScope = lexicalContent ?
+						this.scope :
+						hookupOptions.scope.add(this.scope),
 					options = {
 						helpers: {}
 					};
@@ -300,12 +308,20 @@ steal("can/util", "can/view/callbacks","can/control", "can/observe", "can/view/m
 
 							delete options.tags.content;
 
-							can.view.live.replace([el], subtemplate(
-								// This is the context of where `<content>` was found
-								// which will have the the component's context
-								rendererOptions.scope,
+							// By default, light dom scoping is
+							// dynamic. This means that any `{{foo}}`
+							// bindings inside the "light dom" content of
+							// the component will have access to the
+							// internal scope. This can be overridden to be
+							// lexical with the lexicalContent
+							// option,
+							var opts = !lexicalContent ||
+									subtemplate !== hookupOptions.subtemplate ?
+									rendererOptions :
+									hookupOptions;
 
-								rendererOptions.options));
+							can.view.live.replace([el], subtemplate(
+								opts.scope, opts.options));
 
 							// Restore the content tag so it could potentially be used again (as in lists)
 							options.tags.content = contentHookup;

--- a/component/component.md
+++ b/component/component.md
@@ -263,6 +263,50 @@ only renders friendly messages:
       }
     });
 
+### LeakScope
+
+A component's [can.Component::leakScope leakScope] option controls whether
+the surrounding template where the component is used can directly share
+scope with the component's internal scope. This option defaults to `true`,
+which means `<content>` is able to access internal scope variables on the
+component, and the component will be able to use outside variables when
+used on a page.
+
+For example, if the following component is defined:
+
+    can.Component.extend({
+        tag: "hello-world",
+        leakScope: true, // the default value
+        template: "{{greeting}} <content></content>{{exclamation}}",
+        scope: { greeting: "Hello" }
+    })
+
+And used like so:
+
+    <hello-world>{{greeting}}</hello-world>
+
+With the following data in the surrounding scope:
+
+    { greeting: "World", exclamation: "!" }
+
+Will render the following if `leakScope` is true:
+
+    <hello-world>Hello Hello!</hello-world>
+
+But if `leakScope` is false:
+
+    <hello-world>Hello World</hello-world>
+
+Because when the scope isn't leaked, the internal `template` for the
+component does not see the surrounding binding for `exclamation` or
+`greeting`, and simply uses its internal `scope` to render its
+template. This also affects where the `{{greeting}}` will be looked up, in
+the light dom.
+
+Using the `leakScope: false` option is useful for hiding and protecting
+internal details of `can.Component`, potentially preventing accidental
+clashes.
+
 ## Differences between components in can.mustache and can.stache
 
 A [can.mustache] template passes values from the scope to a `can.Component`

--- a/component/component.md
+++ b/component/component.md
@@ -9,7 +9,7 @@
 @description Create widgets that use a template, a view-model 
 and custom tags.
 
-@deprecated {2.1} To pass data from the scope, you must wrap your attribute 
+@warning {2.1} To pass data from the scope, you must wrap your attribute
 value with `{}`. In 3.0, [can.mustache]
 will use [can.stache]'s method.
 
@@ -262,50 +262,6 @@ only renders friendly messages:
         }
       }
     });
-
-### LeakScope
-
-A component's [can.Component::leakScope leakScope] option controls whether
-the surrounding template where the component is used can directly share
-scope with the component's internal scope. This option defaults to `true`,
-which means `<content>` is able to access internal scope variables on the
-component, and the component will be able to use outside variables when
-used on a page.
-
-For example, if the following component is defined:
-
-    can.Component.extend({
-        tag: "hello-world",
-        leakScope: true, // the default value
-        template: "{{greeting}} <content></content>{{exclamation}}",
-        scope: { greeting: "Hello" }
-    })
-
-And used like so:
-
-    <hello-world>{{greeting}}</hello-world>
-
-With the following data in the surrounding scope:
-
-    { greeting: "World", exclamation: "!" }
-
-Will render the following if `leakScope` is true:
-
-    <hello-world>Hello Hello!</hello-world>
-
-But if `leakScope` is false:
-
-    <hello-world>Hello World</hello-world>
-
-Because when the scope isn't leaked, the internal `template` for the
-component does not see the surrounding binding for `exclamation` or
-`greeting`, and simply uses its internal `scope` to render its
-template. This also affects where the `{{greeting}}` will be looked up, in
-the light dom.
-
-Using the `leakScope: false` option is useful for hiding and protecting
-internal details of `can.Component`, potentially preventing accidental
-clashes.
 
 ## Differences between components in can.mustache and can.stache
 

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -189,6 +189,55 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.remove(can.$("#qunit-fixture>*"));
 	});
 
+	test("lexical scoping", function() {
+		can.Component.extend({
+			tag: "hello-world",
+			leakScope: false,
+			template: can.view.mustache("{{greeting}} <content>World</content>{{exclamation}}"),
+			scope: {greeting: "Hello"}
+		});
+		var template = can.view.mustache("<hello-world>{{greeting}}</hello-world>");
+		can.append(can.$("#qunit-fixture"), template({
+			greeting: "World",
+			exclamation: "!"
+		}));
+		var hello = can.$("#qunit-fixture hello-world");
+		equal(hello[0].innerHTML.trim(), "Hello World");
+		can.remove(can.$("#qunit-fixture > *"));
+
+		can.Component.extend({
+			tag: "hello-world-no-template",
+			leakScope: false,
+			scope: {greeting: "Hello"}
+		});
+		template = can.view.mustache("<hello-world-no-template>{{greeting}}</hello-world-no-template>");
+		can.append(can.$("#qunit-fixture"), template({
+			greeting: "World",
+			exclamation: "!"
+		}));
+		hello = can.$("#qunit-fixture hello-world-no-template");
+		equal(hello[0].innerHTML.trim(), "Hello",
+			  "If no template is provided to can.Component, treat <content> bindings as dynamic.");
+		can.remove(can.$("#qunit-fixture > *"));
+	});
+
+	test("dynamic scoping", function() {
+		can.Component.extend({
+			tag: "hello-world",
+			leakScope: true,
+			template: can.view.mustache("{{greeting}} <content>World</content>{{exclamation}}"),
+			scope: {greeting: "Hello"}
+		});
+		var template = can.view.mustache("<hello-world>{{greeting}}</hello-world>");
+		can.append(can.$("#qunit-fixture"), template({
+			greeting: "World",
+			exclamation: "!"
+		}));
+		var hello = can.$("#qunit-fixture hello-world");
+		equal(hello[0].innerHTML.trim(), "Hello Hello!");
+		can.remove(can.$("#qunit-fixture > *"));
+	});
+
 	test("treecombo", function () {
 
 		can.Component.extend({
@@ -728,10 +777,11 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 
 		can.Component.extend({
 			tag: 'my-scope',
+			template: "{{name}}}",
 			scope: me
 		});
 
-		var template = can.view.mustache('<my-scope>{{name}}</my-scope>');
+		var template = can.view.mustache('<my-scope></my-scope>');
 		equal(template()
 			.childNodes[0].innerHTML, "Justin");
 
@@ -1177,10 +1227,11 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		var Constructed = can.Construct.extend({foo:"bar"},{});
 		
 		can.Component.extend({
-			tag: "con-struct"
+			tag: "con-struct",
+			template: "{{con.foo}}"
 		});
 		
-		var stached = can.stache("<con-struct con='{Constructed}'>{{con.foo}}</con-struct>");
+		var stached = can.stache("<con-struct con='{Constructed}'></con-struct>");
 		
 		var res = stached({
 			Constructed: Constructed
@@ -1247,10 +1298,10 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 	});
 	
 	test("hyphen-less tag names", function () {
-		var template = can.view.mustache('<span></span><foobar>{{name}}</foobar>');
+		var template = can.view.mustache('<span></span><foobar></foobar>');
 		can.Component.extend({
 			tag: "foobar",
-			template: "<div><content/></div>",
+			template: "<div>{{name}}</div>",
 			scope: {
 				name: "Brian"
 			}

--- a/component/leakscope.md
+++ b/component/leakscope.md
@@ -1,0 +1,44 @@
+@property {Boolean} can.Component.prototype.leakScope
+@parent can.Component.prototype
+
+A component's [can.Component::leakScope leakScope] option controls whether
+the surrounding template where the component is used can directly share
+scope with the component's internal scope. This option defaults to `true`,
+which means `<content>` is able to access internal scope variables on the
+component, and the component will be able to use outside variables when
+used on a page.
+
+For example, if the following component is defined:
+
+    can.Component.extend({
+        tag: "hello-world",
+        leakScope: true, // the default value
+        template: "{{greeting}} <content></content>{{exclamation}}",
+        scope: { greeting: "Hello" }
+    })
+
+And used like so:
+
+    <hello-world>{{greeting}}</hello-world>
+
+With the following data in the surrounding scope:
+
+    { greeting: "World", exclamation: "!" }
+
+Will render the following if `leakScope` is true:
+
+    <hello-world>Hello Hello!</hello-world>
+
+But if `leakScope` is false:
+
+    <hello-world>Hello World</hello-world>
+
+Because when the scope isn't leaked, the internal `template` for the
+component does not see the surrounding binding for `exclamation` or
+`greeting`, and simply uses its internal `scope` to render its
+template. This also affects where the `{{greeting}}` will be looked up, in
+the light dom.
+
+Using the `leakScope: false` option is useful for hiding and protecting
+internal details of `can.Component`, potentially preventing accidental
+clashes.


### PR DESCRIPTION
Fixes #1069