### PR TITLE
Ensure can-value bound input stay in sync with compute

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -245,7 +245,7 @@ steal("can/util", "can/view/callbacks", "can/control", function (can) {
 			var el = this.element[0];
 			
 			// Set the value of the attribute passed in to reflect what the user typed
-			this.options.value(el.value)
+			this.options.value(el.value);
 			var newVal = this.options.value();
 			
 			// If the newVal isn't the same as the input, set it's value

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -245,7 +245,8 @@ steal("can/util", "can/view/callbacks", "can/control", function (can) {
 			var el = this.element[0];
 			
 			// Set the value of the attribute passed in to reflect what the user typed
-			var newVal = this.options.value(el.value);
+			this.options.value(el.value)
+			var newVal = this.options.value();
 			
 			// If the newVal isn't the same as the input, set it's value
 			if(el.value !== newVal) {


### PR DESCRIPTION
I merged and resolved conflict from Matthew's original PR #888. And updated setter based on Justin's reco here: #888 (diff)

Matthew's PR fixes #887: can-value becomes out of sync when a compute rejects the new value #887