### PR TITLE
Fixes #1388 and #1389 Passing partial set in options

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1699,8 +1699,9 @@ steal('can/util',
 			if (!can.view.cached[partial]) {
 				// we don't want to bind to changes so clear and restore reading
 				var reads = can.__clearReading();
-				if (scope.attr('partial')) {
-					partial = scope.attr('partial');
+				var scopePartialName = scope.attr(partial);
+				if (scopePartialName) {
+					partial = scopePartialName;
 				}
 				can.__setReading(reads);
 			}

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -3901,4 +3901,21 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		ok( typeof Mustache.getHelper('myHelper').fn === 'function' );
 		ok( Mustache.getHelper('myHelper').fn() );
 	});
+
+	test("Passing Partial set in options (#1388 and #1389).", function () {
+		var data = new can.Map({
+			name: "World",
+			greeting: "hello"
+		});
+
+		can.view.registerView("hello", "hello {{name}}", ".mustache");
+
+		var template = can.view.mustache("<div>{{>greeting}}</div>")(data);
+
+		var div = document.createElement("div");
+		div.appendChild(template);
+		equal(div.innerHTML, "<div>hello World</div>", "partial retreived and rendered");
+
+	});
+
 });

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3655,5 +3655,24 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs",fu
 		equal(frag.childNodes[0].className, "foo", "correct class name");
 		equal(frag.childNodes[0].innerHTML, "bar", "correct innerHTMl");
 	});
-	
+
+	test("Passing Partial set in options (#1388 and #1389). Support live binding of partial", function () {
+		var data = new can.Map({
+			name: "World",
+			greeting: "hello"
+		});
+
+		can.view.registerView("hello", "hello {{name}}", ".stache");
+		can.view.registerView("goodbye", "goodbye {{name}}", ".stache");
+
+		var template = can.stache("<div>{{>greeting}}</div>")(data);
+
+		var div = document.createElement("div");
+		div.appendChild(template);
+		equal(div.innerHTML, "<div>hello World</div>", "partial retreived and rendered");
+
+		data.attr("greeting", "goodbye");
+		equal(div.innerHTML, "<div>goodbye World</div>", "Partial updates when attr is updated");
+
+	});
 });


### PR DESCRIPTION
Look up partial reference in scope. For stache, this also wraps the partial in a compute so it can be live bound.