### PR TITLE
Ensure can-value bound input stay in sync with compute

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -244,13 +244,22 @@ steal("can/util", "can/view/callbacks", "can/control", function (can) {
 			this.element[0].value = (val == null ? '' : val);
 		},
 		// If the input value changes, this will set the live bound data to reflect the change.
+			// If the input value changes, this will set the live bound data to reflect the change.
 		"change": function () {
 			// This may happen in some edgecases, esp. with selects that are not in DOM after the timeout has fired
 			if (!this.element) {
 				return;
 			}
+			var el = this.element[0];
+
 			// Set the value of the attribute passed in to reflect what the user typed
-			this.options.value(this.element[0].value);
+			this.options.value(el.value);
+			var newVal = this.options.value();
+
+			// If the newVal isn't the same as the input, set it's value
+			if(el.value !== newVal) {
+				el.value = newVal;
+			}
 		}
 	}),
 	// ### Checked 

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -615,5 +615,33 @@ steal("can/view/bindings", "can/map", "can/test", "can/view/stache", function (s
 		equal(clickHandlerCount, 2, "click handler called twice");
 	});
 
+	test("can-value compute rejects new value (#887)", function() {
+		var template = can.view.mustache("<input can-value='age'/>");
+
+		// Compute only accepts numbers
+		var compute = can.compute(30, function(newVal, oldVal) {
+			if(isNaN(+newVal)) {
+				return oldVal;
+			} else {
+				return +newVal;
+			}
+		});
+
+		var frag = template({
+			age: compute
+		});
+
+		var ta = document.getElementById("qunit-test-area");
+		ta.appendChild(frag);
+
+		var input = ta.getElementsByTagName("input")[0];
+
+		// Set to non-number
+		input.value = "30f";
+		can.trigger(input, "change");
+
+		equal(compute(), 30, "Still the old value");
+		equal(input.value, "30", "Text input has also not changed");
+	});
 
 });


### PR DESCRIPTION
Fixes #888, fixes #887 and fixes #872