### PR TITLE
To use the old-style fixture:false; rather than creating an arbitrary property.

### DIFF
--- a/util/fixture/doc/fixture.md
+++ b/util/fixture/doc/fixture.md
@@ -175,6 +175,23 @@ You can also set [can.fixture.on] to false:
 
     can.fixture.on = false;
 
+## Bypassing Fixtures
+
+While there are few cases where you would need to, it is possible to bypass a
+fixture completely, without turning off fixtures globally. This is done by passing
+`fixture: false` to your AJAX settings. This will prevent `can.fixture` from
+trapping your request, and actually send it to the server.
+
+    // add a fixture
+    can.fixture('POST /foo', '//fixtures/foo.json');
+
+    // Send AJAX call to server, even if fixtures are on
+    can.ajax({
+        type: 'POST',
+        url: '/foo',
+        fixture: false
+    });
+
 ## can.fixture.store
 
 [can.fixture.store] makes a CRUD service layer that handles sorting, grouping, filtering and more. Use

--- a/util/fixture/fixture.js
+++ b/util/fixture/fixture.js
@@ -42,7 +42,7 @@ steal('can/util', 'can/util/string', 'can/util/object', function (can) {
 	// manipulate the AJAX call to change the URL to a static file or call
 	// a function for a dynamic fixture.
 	var updateSettings = function (settings, originalOptions) {
-		if (!can.fixture.on) {
+		if (!can.fixture.on || settings.fixture === false) {
 			return;
 		}
 

--- a/util/fixture/fixture_test.js
+++ b/util/fixture/fixture_test.js
@@ -571,6 +571,27 @@ steal('can/util/fixture', 'can/model', 'can/test', 'steal-qunit', function () {
 		});
 		
 	});
+
+	test("fixture: false flag circumvents can.fixture", function() {
+
+		can.fixture("GET /thinger/mabobs", function (settings) {
+			return {
+				thingers: "mabobs"
+			};
+		});
+
+		stop();
+		can.ajax({
+			url: "/thinger/mabobs",
+			method: "GET",
+			fixture: false,
+			error: function() {
+				ok(true, 'AJAX errors out as expected');
+				start();
+			}
+		});
+
+	});
 	
 	
 });


### PR DESCRIPTION
Fixes #1131