### PR TITLE
Added jquery to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
 		"url": "git@github.com:bitovi/canjs.git",
 		"github": "https://github.com/bitovi/canjs"
 	},
+	"peerDependencies": {
+		"jquery": ">=1.9.0 <3.0.0"
+	},
 	"devDependencies": {
 		"bitovi-tools": "git://github.com/bitovi/bitovi-tools.git#steal-tools",
 		"bower": "~1.3.8",
@@ -31,7 +34,7 @@
 		"grunt-shell": "~0.5.0",
 		"grunt-simple-mocha": "^0.4.0",
 		"grunt-string-replace": "~0.2.2",
-		"jquery": "~1.11.0",
+		"jquery": ">=1.9.0 <3.0.0",
 		"lodash": "2.4.1",
 		"rimraf": "2.1",
 		"steal": "0.6.0-pre.0",


### PR DESCRIPTION
Changed the verion of the required jquery to a range of 1.9.0 to less than 3.0.0

Kept jquery in dev dependencies so that it can be install at the root level of canjs via npm install