### PR TITLE
Use _setupDefaults in lazyMap

### DIFF
--- a/map/lazy/lazy.js
+++ b/map/lazy/lazy.js
@@ -8,7 +8,7 @@ steal('can/util', './bubble.js', 'can/map', 'can/list', './nested_reference.js',
 			this.constructor.List = can.LazyList;
 
 			// `_data` is where we keep the properties.
-			this._data = can.extend(can.extend(true, {}, this.constructor.defaults || {}), obj);
+			this._data = can.extend(can.extend(true, {}, this._setupDefaults() || {}), obj);
 
 			// The namespace this `object` uses to listen to events.
 			can.cid(this, ".lazyMap");


### PR DESCRIPTION
LazyMap should use `_setupDefaults` instead of accessing the defaults directly. Closes #1280