### PR TITLE
Add check in live.list to determine if current event is part of a batch.

### DIFF
--- a/util/batch/batch.js
+++ b/util/batch/batch.js
@@ -173,6 +173,8 @@ steal('can/util/can.js', function (can) {
 					i, len;
 				batchEvents = [];
 				stopCallbacks = [];
+				// Capture current batchNum so it can be check in live bindings
+				can.batch.batchNum = batchNum;
 				batchNum++;
 				if (callStart) {
 					can.batch.start();
@@ -183,6 +185,7 @@ steal('can/util/can.js', function (can) {
 				for(i = 0, len = callbacks.length; i < callbacks.length; i++) {
 					callbacks[i]();
 				}
+				can.batch.batchNum = undefined;
 			}
 		},
 		/**

--- a/view/live/live.js
+++ b/view/live/live.js
@@ -148,15 +148,20 @@ steal('can/util', 'can/view/elements.js', 'can/view', 'can/view/node_lists', 'ca
 		 *
 		 */
 		list: function (el, compute, render, context, parentNode, nodeList) {
-			
+			//var setupBatchNum = can.batch.batchNum;
+
 			// A nodeList of all elements this live-list manages.
 			// This is here so that if this live list is within another section
 			// that section is able to remove the items in this list.
 			var masterNodeList = nodeList || [el],
 				// A mapping of items to their indicies'
 				indexMap = [],
+				// Capture current batchNum
+				setupBatchNum = can.batch.batchNum,
 				// Called when items are added to the list.
 				add = function (ev, items, index) {
+					// if the event's batchNum equals setupBatchNum then we're in the middle of a batch job.
+					if (ev.batchNum && ev.batchNum === setupBatchNum) {return;}
 					// Collect new html and mappings
 					var frag = document.createDocumentFragment(),
 						newNodeLists = [],

--- a/view/view_test.js
+++ b/view/view_test.js
@@ -835,4 +835,28 @@ steal("can/view/callbacks",
 			start();
 		});
 	});
+
+	test('live lists are rendered properly when batch updated (#680)', function () {
+		var div1 = document.createElement('div'),
+			div2 = document.createElement('div'),
+			template = "{{#if items.length}}<ul>{{#each items}}<li>{{.}}</li>{{/each}}</ul>{{/if}}",
+			stacheTempl = can.stache(template),
+			mustacheTempl = can.mustache(template);
+
+		var data = {
+			items: new can.List()
+		};
+
+		div1.appendChild(stacheTempl(data));
+		div2.appendChild(mustacheTempl(data));
+
+		can.batch.start();
+		for (var i=1; i<=3; i++) {
+			data.items.push(i);
+		}
+		can.batch.stop();
+
+		equal(div1.innerText, "123", "Batched lists rendered properly with stache.");
+		equal(div2.innerText, "123", "Batched lists rendered properly with mustache.");
+	});
 });


### PR DESCRIPTION
Add a batchNum property to can.batch. Add check in can.live.list add method to determine if current event was triggered during a batch job. if so, then exit the add. Fixes #680.