### PR TITLE
can.import works with RequireJS

### DIFF
--- a/util/can.js
+++ b/util/can.js
@@ -91,7 +91,7 @@ steal(function () {
 		if(typeof window.System === "object") {
 			window.System["import"](moduleName).then(can.proxy(deferred.resolve, deferred),
 				can.proxy(deferred.reject, deferred));
-		} else if(window.require && window.require.amd){
+		} else if(window.define && window.define.amd){
 			
 			window.require([moduleName], function(value){
 				deferred.resolve(value);

--- a/view/autorender/autorender.js
+++ b/view/autorender/autorender.js
@@ -62,10 +62,14 @@ steal("can/util",function(can){
 			var text = el.innerHTML || el.text,
 				typeAttr = el.getAttribute("type"),
 				typeInfo = typeAttr.match( typeMatch ),
-				type = typeInfo && typeInfo[1];
+				type = typeInfo && typeInfo[1],
+				typeModule = "can/view/" + type;
+
+			if(!(window.define && window.define.amd)) {
+				typeModule += "/" + type;
+			}
 			
-			
-			promises.push( can["import"]("can/view/"+type+"/"+type).then(function(engine){
+			promises.push( can["import"](typeModule).then(function(engine){
 				
 				engine = can[type] || engine;
 				if(engine.async) {
@@ -96,7 +100,7 @@ steal("can/util",function(can){
 	}
 	var promise = deferred.promise();
 	can.autorender = function(success, error){
-		promise.then(success, error);
+		return promise.then(success, error);
 	};
 	return can.autorender;
 });

--- a/view/autorender/autorender_test.js
+++ b/view/autorender/autorender_test.js
@@ -20,7 +20,7 @@ steal("can/test", "steal-qunit", function () {
 
 	if(window.requirejs) {
 		asyncTest("the basics are able to work for requirejs", function(){
-			makeIframe(can.test.path("view/autorender/tests/steal-basics.html?"+Math.random()));
+			makeIframe(can.test.path("view/autorender/tests/requirejs-basics.html?"+Math.random()));
 		});
 	}
 

--- a/view/autorender/autorender_test.js
+++ b/view/autorender/autorender_test.js
@@ -15,7 +15,12 @@ steal("can/test", "steal-qunit", function () {
 	if(window.steal) {
 		asyncTest("the basics are able to work for steal", function(){
 			makeIframe(  can.test.path("view/autorender/tests/steal-basics.html?"+Math.random()) );
-			
+		});
+	}
+
+	if(window.requirejs) {
+		asyncTest("the basics are able to work for requirejs", function(){
+			makeIframe(can.test.path("view/autorender/tests/steal-basics.html?"+Math.random()));
 		});
 	}
 

--- a/view/autorender/tests/requirejs-basics.html
+++ b/view/autorender/tests/requirejs-basics.html
@@ -1,0 +1,40 @@
+<script>
+	window.QUnit = window.parent.QUnit;
+	window.removeMyself = window.parent.removeMyself;
+</script>
+<script type='text/stache' id='basics' can-autorender>
+	<can-import from="./requirejs-basics"/>
+	<my-component></my-component>
+</script>
+<script src='../../../bower_components/requirejs/require.js'></script>
+<script>
+	require.config({
+		paths: {
+			"can": "../../../dist/amd/can",
+			"jquery": "../../../lib/jquery.1.9.1"
+		},
+	});
+
+	require(['can/view/autorender'],function(ready){
+		ready(function(){
+			if(window.QUnit) {
+				QUnit.equal( $("body my-component").length, 1,"only one my-component" );
+				QUnit.equal( $("body my-component").html(), "Hello World","template rendered" );
+				QUnit.equal( $("body my-component")[0].className, "inserted","template rendered" );
+				removeMyself();
+			} else {
+				console.log( $("body my-component").length );
+				console.log( $("body my-component").html() );
+			}
+			
+		}, function(error){
+			if(window.QUnit) {
+				
+				QUnit.ok( false, "error in autoload");
+				removeMyself();
+			} else {
+				console.log("error in autoload", error)
+			}
+		});
+	});
+</script>

--- a/view/autorender/tests/requirejs-basics.js
+++ b/view/autorender/tests/requirejs-basics.js
@@ -1,0 +1,15 @@
+define(["can/component", "can"], function(Component, can){
+	return Component.extend({
+		tag: "my-component",
+		// call can.stache b/c it should be imported auto-magically
+		template: can.stache("{{message}}"),
+		scope: {
+			message: "Hello World"
+		},
+		events: {
+			"inserted": function(){
+				this.element[0].className = "inserted";
+			}
+		}
+	});
+});


### PR DESCRIPTION
This fixes can.import to work with RequireJS. 2 things needed:

1. can.import checks for define && define.amd instead of window.require
(window.require.amd doesn't exist).

2. can.autorender has to pass in the correct moduleName for AMD.

Fixes #1456