### PR TITLE
Add a "compute" type converter to the Define plugin

### DIFF
--- a/map/define/doc/type.md
+++ b/map/define/doc/type.md
@@ -21,6 +21,10 @@ The `type` property specifies the type of the attribute.  The type can be specif
  - `"htmlbool"` - Like `boolean`, but also converts empty strings to
    `true`. Used, for example, when input is from component attributes like
    `<can-tabs reverse/>`
+ - `"compute"` - Converts the value to a compute initially. Subsequent calls to
+   `can.Map.prototype.attr` will set/get the `can.compute`'s value as opposed
+   to explicitly overwriting the properties value. If a `can.compute` is passed
+   to `can.Map.prototype.attr` it will replace the property's current `can.compute`.
  - `"*"` - Prevents the default type coersion of converting Objects to [can.Map]s and Arrays to [can.List]s.
 
 ### Basic Example

--- a/map/map.js
+++ b/map/map.js
@@ -300,14 +300,22 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 
 				for (var i = 0, len = computes.length, prop; i < len; i++) {
 					prop = computes[i];
-					// Make the context of the compute the current Map
-					this[prop] = this[prop].clone(this);
-					// Keep track of computed properties
-					this._computedBindings[prop] = {
-						count: 0
-					};
+					// Make the context of the compute the current Map, if it's
+					// already a defined property of this Map
+					if (this[prop]) {
+						this[prop] = this[prop].clone(this);
+					}
+					this._trackCompute(prop);
 				}
 			},
+
+			_trackCompute: function (prop) {
+				// Keep track of computed properties
+				this._computedBindings[prop] = {
+					count: 0
+				};
+			},
+
 			_setupDefaults: function(){
 				return this.constructor.defaults || {};
 			},


### PR DESCRIPTION
Currently you can set/get a `can.compute`'s value with `can.Map.prototype.attr` if it is defined as a property of the map's prototype. Example: 

```
var MapWithCompute = can.Map.extend({
  computed: can.compute(0, function (newVal, oldVal) {
      if (typeof newVal !== 'undefined') {
          return newVal; 
      }
      return oldVal; 
  })
}); 

var m = new MapWithCompute({
    computed: 1
}); 
console.log(m.attr('computed')); // -> 1

m.attr('computed', 2); 

console.log(m.attr('computed')); // -> 2
```
http://jsfiddle.net/akagomez/90ottotb/

However, if you set the value of a property on a `can.Map` to a `can.compute` *using* `can.Map.prototype.attr`, the API for setting/getting that `can.computes` value changes. Example: 

```
var MapWithCompute = can.Map.extend({}); 

var m = new MapWithCompute();
m.attr({
    computed: can.compute(0, function (newVal, oldVal) {
        if (typeof newVal !== 'undefined') {
            return newVal; 
        }
        return oldVal; 
    })
}); 
console.log(typeof m.attr('computed')); // -> function
console.log(m.attr('computed')()); // -> 0

m.attr('computed', 2); 

console.log(m.attr('computed')); // -> 2
console.log(typeof m.attr('computed')); // -> 'number'
```
http://jsfiddle.net/akagomez/jt9x7kmr/

This is due to the fact that `can.Map.prototype.attr`sets/gets the value explicitly, per #530. 

By adding a "compute" type to the Define plugin (and extending `can.Map.prototype.___set`) I was able to process `can.compute`'s that are set with `can.Map.prototype.attr` in the same way that `can.computes` are processed on the prototype with `can.Map.prototype.setup`. 

This enables us to do things like this: 

```
var ToggleMap = can.Map.extend({
	define: {
		computable: {
			type: 'compute'
		}
	}
});

var toggleCompute = can.compute(false);

var sharedToggle1 = new ToggleMap({
	computable: toggleCompute
});

var sharedToggle2 = new ToggleMap({
	computable: toggleCompute
});

var soloToggle = new ToggleMap({
	computable: false // Converted to can.compute
});

console.log(sharedToggle1.attr('computable')); // -> false
console.log(sharedToggle2.attr('computable')); // -> false
console.log(soloToggle.attr('computable')); // -> false

// Update a reference to the compute
sharedToggle1.attr('computable', true);

console.log(sharedToggle1.attr('computable')); // -> true
console.log(sharedToggle2.attr('computable')); // -> true
console.log(soloToggle.attr('computable')); // -> false

// Update a reference to the compute
sharedToggle2.attr('computable', false);

console.log(sharedToggle1.attr('computable')); // -> false
console.log(sharedToggle2.attr('computable')); // -> false
console.log(soloToggle.attr('computable')); // -> false

// Update a reference to the compute
toggleCompute(true);

console.log(sharedToggle1.attr('computable')); // -> true
console.log(sharedToggle2.attr('computable')); // -> true
console.log(soloToggle.attr('computable')); // -> false
``` 

Closes #1409 