### PR TITLE
Make sure fixture .create, .update and .destroy work 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -241,7 +241,7 @@ module.exports = function (grunt) {
 		testee: {
 			options: {
 				timeout: 10000,
-				reporter: 'Spec'
+				reporter: 'Dot'
 			},
 			steal: [
 				'test/*.html',

--- a/util/fixture/fixture.js
+++ b/util/fixture/fixture.js
@@ -648,7 +648,7 @@ steal('can/util', 'can/util/string', 'can/util/object', function (can) {
 				// ## fixtureStore.create
 				// Simulates a can.Model.create to a fixture
 				create: function (settings, response) {
-					var item = make(items.length, items);
+					var item = typeof make === 'function' ? make(items.length, items) : {};
 
 					can.extend(item, settings.data);
 

--- a/util/fixture/test.html
+++ b/util/fixture/test.html
@@ -1,3 +1,3 @@
-<title>can/util</title>
+<title>can/util/fixture</title>
 <script src="../../node_modules/steal/steal.js" main="can/util/fixture/fixture_test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
This pull request makes sure that `fixture.store` initialized with an object works for `.create`, `.update` and `.destroy`. Closes #1471.