### PR TITLE
trim can-value binding attributes

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -69,7 +69,7 @@ steal("can/util", "can/view/callbacks", "can/control", function (can) {
 	// should be a string representing some value in the current scope to cross-bind to.
 	can.view.attr("can-value", function (el, data) {
 
-		var attr = removeCurly(el.getAttribute("can-value")),
+		var attr = can.trim(removeCurly(el.getAttribute("can-value"))),
 			// Turn the attribute passed in into a compute.  If the user passed in can-value="name" and the current 
 			// scope of the template is some object called data, the compute representing this can-value will be the 
 			// data.attr('name') property.

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -94,6 +94,36 @@ steal("can/view/bindings", "can/map", "can/test", "can/view/mustache", "can/view
 
 	});
 
+	test("can-value with spaces (#1477)", function () {
+
+		var template = can.view.stache("<input can-value='{ age }'/>");
+
+		var map = new can.Map();
+
+		var frag = template(map);
+
+		var ta = document.getElementById("qunit-fixture");
+		ta.appendChild(frag);
+
+		var input = ta.getElementsByTagName("input")[0];
+		equal(input.value, "", "input value set correctly if key does not exist in map");
+
+		map.attr("age", "30");
+
+		equal(input.value, "30", "input value set correctly");
+
+		map.attr("age", "31");
+
+		equal(input.value, "31", "input value update correctly");
+
+		input.value = "32";
+
+		can.trigger(input, "change");
+
+		equal(map.attr("age"), "32", "updated from input");
+
+	});
+
 	test("can-value input radio", function () {
 
 		var template = can.view.stache(


### PR DESCRIPTION
Makes sure that can-value bindings are trimmed. Closes #1477