### PR TITLE
can-value for checkboxes should only check loose equality

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -284,7 +284,7 @@ steal("can/util", "can/view/callbacks", "can/control", function (can) {
 						trueValue = this.options.trueValue || true;
 					// If `can-true-value` attribute was set, check if the value is equal to that string value, and set 
 					// the checked property based on their equality.
-					this.element[0].checked = (value === trueValue);
+					this.element[0].checked = (value == trueValue);
 				}
 				// Its a radio input type
 				else {

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -713,4 +713,17 @@ steal("can/view/bindings", "can/map", "can/test", "can/view/mustache", "can/view
 		}, 1);
 
 	});
+
+	test('can-value with truthy and falsy values binds to checkbox (#1478)', function() {
+		var data = new can.Map({
+				completed: 1
+			}),
+			frag = can.view.stache('<input type="checkbox" can-value="completed"/>')(data);
+		can.append(can.$("#qunit-fixture"), frag);
+
+		var input = can.$("#qunit-fixture")[0].getElementsByTagName('input')[0];
+		equal(input.checked, true, 'checkbox value bound (via attr check)');
+		data.attr('completed', 0);
+		equal(input.checked, false, 'checkbox value bound (via attr check)');
+	});
 });


### PR DESCRIPTION
This pull request changes `can-value` checks for checkboxes to loose equality to close #1478.