### PR TITLE
Added a note and some sample code illustrating relative can.view.Scope.attr lookups.

### DIFF
--- a/view/scope/doc/attr.md
+++ b/view/scope/doc/attr.md
@@ -19,5 +19,25 @@ will be explored.
 
     var curScope = new can.view.Scope(list).add(justin);
 
-    curScope.attr("name") //-> "Justin"
-    curScope.attr("length") //-> 2
+    curScope.attr("name"); //-> "Justin"
+    curScope.attr("length"); //-> 2
+
+Prefixing a key with `"./"` prevents any parent scope look ups.
+Prefixing a key with one or more `"../"` shifts the lookup path
+that many levels up.
+
+    var list = [{name: "Justin"},{name: "Brian"}];
+    list.name = "Programmers";
+    list.surname = "CanJS";
+
+    var justin = list[0];
+    var brian = list[1];
+    var curScope = new can.view.Scope(list).add(justin).add(brian);
+
+    curScope.attr("name"); //-> "Brian"
+    curScope.attr("surname"); //-> "CanJS"
+    curScope.attr("./surname"); //-> undefined
+    curScope.attr("../name"); //-> "Justin"
+    curScope.attr("../surname"); //-> "CanJS"
+    curScope.attr(".././surname"); //-> "undefined"
+    curScope.attr("../../name"); //-> "Programmers"

--- a/view/scope/scope.md
+++ b/view/scope/scope.md
@@ -14,7 +14,7 @@
 
 @param {*} context A value that represents the 
 current context. This is often an object or observable and is the first
-place 
+place a `key` is looked up.
 
 @param {can.view.Scope} [parent] The parent scope. If a `key` value
 is not found in the current scope, it will then look in the parent
@@ -50,7 +50,7 @@ searched in the parent's context after the initial context is explored.  For exa
     curScope.attr("name") //-> "Justin"
     curScope.attr("length") //-> 2
 
-Use [can.view.Scope.prototype.add add] to easily create a new scope from a parent scope like:
+Use [can.view.Scope::add add] to easily create a new scope from a parent scope like:
 
 
     var list = [{name: "Justin"},{name: "Brian"}],


### PR DESCRIPTION
Closes #1146

These changes will be reflected at http://canjs.com/docs/can.view.Scope.attr.html and http://canjs.com/docs/can.view.Scope.html when the documents are regenerated.