### PR TITLE
Add makeDestroy to model.

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -591,7 +591,8 @@ steal('can/util', 'can/map', 'can/list', function (can) {
 		makeFindAll: makeGetterHandler("models"),
 		makeFindOne: makeGetterHandler("model"),
 		makeCreate: createUpdateDestroyHandler,
-		makeUpdate: createUpdateDestroyHandler
+		makeUpdate: createUpdateDestroyHandler,
+		makeDestroy: createUpdateDestroyHandler
 	};
 
 	// Go through the response handlers and make the actual "make" methods.


### PR DESCRIPTION
This pull request adds a `makeDestroy` method and closes #1469 (although not fully reproducible and this fix does not break anything else).