### PR TITLE
Argument support for can-EVENT

### DIFF
--- a/util/yui/yui.js
+++ b/util/yui/yui.js
@@ -153,6 +153,7 @@ steal('can/util/can.js', "can/util/attr", 'yui', 'can/event',
 			return wrapped.addClass(className);
 		};
 		can.data = function (wrapped, key, value) {
+			if(!wrapped.item(0)) { return; }
 			if (value === undefined) {
 				return wrapped.item(0)
 					.getData(key);

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -195,6 +195,8 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 
 				// We break out early if the first argument isn't available
 				// anywhere.
+				
+				//!steal-remove-start
 				if (!scopeData.value) {
 					can.dev.warn("can/view/bindings: " + attributeName + " couldn't find method named " + attrInfo.name.get, {
 						element: el,
@@ -202,13 +204,14 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 					});
 					return null;
 				}
+				//!steal-remove-end
 
 				var args = [];
 				var $el = can.$(this);
 				var localScope = data.scope.add({
 					"@element": $el,
 					"@event": ev,
-					"@scope": typeof $el.scope === "function" && $el.scope(),
+					"@scope": can.scope($el[0]),
 					"@context": data.scope._context
 				});
 

--- a/view/bindings/doc/can-event.md
+++ b/view/bindings/doc/can-event.md
@@ -16,12 +16,20 @@ should be a function.
 ## Use
 
 By adding `can-EVENT='KEY'` to an element, the function pointed to
-by `KEY` is bound to the element's `EVENT` event. The function
-is called back with:
+by `KEY` is bound to the element's `EVENT` event. The function can be
+passed any number of arguments from the surrounding scope, or `name=value`
+attributes for named arguments. Direct arguments will be provided to the
+handler in the order they were given, except `name=value` arguments, which
+will all be given as part of a `hash` argument inserted after all direct
+arguments.
 
- - `context` - the context of the element
- - `element` - the element that was bound
- - `event` - the event that was triggered
+The last 3 arguments to the callback will always be the current template
+context, followed by the element, then the event object.
+
+There are also two special variables available within handlers:
+
+ - `@element` - the element that was bound
+ - `@event` - the event that was triggered
 
 @demo can/view/bindings/doc/can-event.html
 


### PR DESCRIPTION
can-EVENT now parses its arguments similar to how stache helpers handle it and prepends those arguments and the hash to the arg list.

Resubmission of #1357 see #1361 and closes #1219 