### PR TITLE
Updates build process to work with Steal 0.7.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -261,7 +261,8 @@ module.exports = function (grunt) {
 	grunt.registerTask('browserify-package', function(){
 		var browser = {"./can": "./dist/cjs/can"};
 		require('./build/config_meta_modules').forEach(function(mod){
-			browser["./"+mod.moduleName] = "./dist/cjs/"+mod.moduleName;
+			var moduleName = mod.moduleName.replace("can/", "");
+			browser["./"+moduleName] = "./dist/cjs/"+moduleName;
 		});
 		var cloned = _.clone(pkg, true);
 		cloned.browser = browser;

--- a/build/config_meta_defaults.js
+++ b/build/config_meta_defaults.js
@@ -1,4 +1,20 @@
+var isNpm = require("steal/ext/npm-utils").moduleName.isNpm;
+
+// Function to remove the npmness from moduleNames
+var denpm = function(moduleName){
+	if(isNpm(moduleName)) {
+		return moduleName.substr(moduleName.indexOf("#") + 1);
+	}
+	return moduleName;
+};
+
 var reverseNormalize = function(name, load, baseName, baseLoad){
+	name = denpm(name);
+
+	if(name === "dist/jquery") {
+		return "jquery";
+	}
+
 	if(name === 'mootools/mootools' || name === 'yui/yui' || name === 'zepto/zepto') {
 		return name.split('/')[0];
 	}

--- a/build/config_meta_modules.js
+++ b/build/config_meta_modules.js
@@ -1,10 +1,13 @@
 var mods = require('../builder.json').modules;
+var pkg = require("../package.json");
+
+var npmPrefix = pkg.name + "@" + pkg.version + "#";
 
 var modules = [];
 
 for(var moduleName in mods) {
 	var mod = mods[moduleName];
-	mod.moduleName = moduleName.replace("can/","");
+	mod.moduleName = moduleName//.replace("can/","");
 	modules.push(mod);
 }
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
 		"jquery": "^1.11.0",
 		"lodash": "2.4.1",
 		"rimraf": "2.1",
-		"steal": "0.6.0-pre.0",
+		"steal": "~0.7.1",
 		"steal-qunit": "0.0.2",
-		"steal-tools": "^0.6.0-pre.3",
+		"steal-tools": "~0.7.1",
 		"testee": "^0.1.3",
 		"zombie": "~2.0.8"
 	},

--- a/util/object/isplain/isplain_test.js
+++ b/util/object/isplain/isplain_test.js
@@ -1,4 +1,4 @@
-steal('./isplain', 'steal-qunit', function() {
+steal('can/util/object/isplain', 'steal-qunit', function() {
 	QUnit.asyncTest('isPlainObject', function () {
 		expect(15);
 		var iframe;

--- a/util/string/deparam/deparam_test.js
+++ b/util/string/deparam/deparam_test.js
@@ -1,4 +1,4 @@
-steal('./deparam', function () {
+steal('can/util/string/deparam', function () {
 	module('can/util/string/deparam');
 	/** /
 test("Basic deparam",function(){


### PR DESCRIPTION
This updates the build process to work with changes to the NPM plugin.  Adding this PR to get a clean build, but wait to merge until after Steal 0.7.1 is released and the dependencies are updated in this branch.