### PR TITLE
Fix can.scope and autorender

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -213,6 +213,11 @@
 			"type": "core",
 			"isDefault": true,
 			"hidden": true
+		},
+		"can/view/autorender/autorender": {
+			"name": "can.autorender",
+			"type": "plugin",
+			"description": "Automatically render templates found in the document"
 		}
 	},
 	"types": {

--- a/component/component.js
+++ b/component/component.js
@@ -482,6 +482,10 @@ steal("can/util", "can/view/callbacks","can/control", "can/observe", "can/view/m
 	can.scope = function (el, attr, val) {
 		el = can.$(el);
 		var scope = can.data(el, "scope");
+		if(!scope) {
+			scope = new can.Map();
+			can.data(el, "scope", scope);
+		}
 		switch (arguments.length) {
 			case 0:
 			case 1:

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -691,6 +691,14 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		}
 	});
 
+	test("can.scope creates one if it doesn't exist", function(){
+		can.append(can.$("#qunit-fixture"), can.view.mustache("<div id='me'></div>")());
+		var el = can.$("#me");
+		var scope = can.scope(el);
+		ok(!!scope, "Scope created where it didn't exist.");
+		equal(scope, can.data(el, "scope"), "Scope is in the data.");
+	});
+
 	test('setting passed variables - two way binding', function () {
 		can.Component({
 			tag: "my-toggler",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
 		"./view/live/live": "./dist/cjs/view/live/live",
 		"./view/scope/scope": "./dist/cjs/view/scope/scope",
 		"./util/string/string": "./dist/cjs/util/string/string",
-		"./util/attr/attr": "./dist/cjs/util/attr/attr"
+		"./util/attr/attr": "./dist/cjs/util/attr/attr",
+		"./view/autorender/autorender": "./dist/cjs/view/autorender/autorender"
 	}
 }

--- a/test/amd/dojo.html
+++ b/test/amd/dojo.html
@@ -55,7 +55,8 @@
                         "can/map/sort", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
-                        "can/util/string", "can/util/attr"
+                        "can/util/string", "can/util/attr",
+                        "can/view/autorender"
                     ]), function() {
                     require(["test/pluginified/latest"], function() {
                         QUnit.start();

--- a/test/amd/jquery-2.html
+++ b/test/amd/jquery-2.html
@@ -57,7 +57,8 @@
                         "can/view/modifiers", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
-                        "can/util/string", "can/util/attr"
+                        "can/util/string", "can/util/attr",
+                        "can/view/autorender"
                     ]), function() {
                     require(["test/pluginified/latest"], function() {
                         QUnit.start();

--- a/test/amd/jquery.html
+++ b/test/amd/jquery.html
@@ -57,7 +57,8 @@
                         "can/view/modifiers", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
-                        "can/util/string", "can/util/attr"
+                        "can/util/string", "can/util/attr",
+                        "can/view/autorender"
                     ]), function() {
                     require(["test/pluginified/latest"], function() {
                         QUnit.start();

--- a/test/amd/mootools.html
+++ b/test/amd/mootools.html
@@ -56,7 +56,8 @@
                         "can/map/sort", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
-                        "can/util/string", "can/util/attr"
+                        "can/util/string", "can/util/attr",
+                        "can/view/autorender"
                     ]), function() {
                     require(["test/pluginified/latest"], function() {
                         QUnit.start();

--- a/test/amd/yui.html
+++ b/test/amd/yui.html
@@ -56,7 +56,8 @@
                         "can/map/sort", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
-                        "can/util/string", "can/util/attr"
+                        "can/util/string", "can/util/attr",
+                        "can/view/autorender"
                     ]), function() {
                     require(["test/pluginified/latest"], function() {
                         QUnit.start();

--- a/test/amd/zepto.html
+++ b/test/amd/zepto.html
@@ -56,7 +56,8 @@
                         "can/map/sort", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
-                        "can/util/string", "can/util/attr"
+                        "can/util/string", "can/util/attr",
+                        "can/view/autorender"
                     ]), function() {
                     require(["test/pluginified/latest"], function() {
                         QUnit.start();

--- a/test/compatibility/dojo.html
+++ b/test/compatibility/dojo.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/compatibility/jquery-2.html
+++ b/test/compatibility/jquery-2.html
@@ -62,6 +62,7 @@
         <script type="text/javascript" src="dist/can.view.modifiers.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/compatibility/jquery.html
+++ b/test/compatibility/jquery.html
@@ -62,6 +62,7 @@
         <script type="text/javascript" src="dist/can.view.modifiers.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/compatibility/mootools.html
+++ b/test/compatibility/mootools.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/compatibility/yui.html
+++ b/test/compatibility/yui.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/compatibility/zepto.html
+++ b/test/compatibility/zepto.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/2.0.5.test.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/dev/dojo.html
+++ b/test/dev/dojo.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             console.log = function() {};

--- a/test/dev/jquery-2.html
+++ b/test/dev/jquery-2.html
@@ -62,6 +62,7 @@
         <script type="text/javascript" src="dist/can.view.modifiers.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             console.log = function() {};

--- a/test/dev/jquery.html
+++ b/test/dev/jquery.html
@@ -62,6 +62,7 @@
         <script type="text/javascript" src="dist/can.view.modifiers.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             console.log = function() {};

--- a/test/dev/mootools.html
+++ b/test/dev/mootools.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             console.log = function() {};

--- a/test/dev/yui.html
+++ b/test/dev/yui.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             console.log = function() {};

--- a/test/dev/zepto.html
+++ b/test/dev/zepto.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             console.log = function() {};

--- a/test/dist/dojo.html
+++ b/test/dist/dojo.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/dist/jquery-2.html
+++ b/test/dist/jquery-2.html
@@ -62,6 +62,7 @@
         <script type="text/javascript" src="dist/can.view.modifiers.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/dist/jquery.html
+++ b/test/dist/jquery.html
@@ -62,6 +62,7 @@
         <script type="text/javascript" src="dist/can.view.modifiers.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/dist/mootools.html
+++ b/test/dist/mootools.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/dist/yui.html
+++ b/test/dist/yui.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/dist/zepto.html
+++ b/test/dist/zepto.html
@@ -60,6 +60,7 @@
         <script type="text/javascript" src="dist/can.list.sort.js"></script>
         <script type="text/javascript" src="dist/can.object.js"></script>
         <script type="text/javascript" src="dist/can.fixture.js"></script>
+        <script type="text/javascript" src="dist/can.autorender.js"></script>
         <script type="text/javascript" src="test/pluginified/latest.js"></script>
         <script type="text/javascript">
             window.require = undefined;

--- a/test/dojo.html
+++ b/test/dojo.html
@@ -51,7 +51,8 @@
                     "can/view/live/live_test.js",
                     "can/view/scope/scope_test.js",
                     "can/util/string/string_test.js",
-                    "can/util/attr/attr_test.js", function() {
+                    "can/util/attr/attr_test.js",
+                    "can/view/autorender/autorender_test.js", function() {
                         can.dev.logLevel = 3;
                     });
             });

--- a/test/jquery-2.html
+++ b/test/jquery-2.html
@@ -53,7 +53,8 @@
                     "can/view/live/live_test.js",
                     "can/view/scope/scope_test.js",
                     "can/util/string/string_test.js",
-                    "can/util/attr/attr_test.js", function() {
+                    "can/util/attr/attr_test.js",
+                    "can/view/autorender/autorender_test.js", function() {
                         can.dev.logLevel = 3;
                     });
             });

--- a/test/jquery.html
+++ b/test/jquery.html
@@ -53,7 +53,8 @@
                     "can/view/live/live_test.js",
                     "can/view/scope/scope_test.js",
                     "can/util/string/string_test.js",
-                    "can/util/attr/attr_test.js", function() {
+                    "can/util/attr/attr_test.js",
+                    "can/view/autorender/autorender_test.js", function() {
                         can.dev.logLevel = 3;
                     });
             });

--- a/test/mootools.html
+++ b/test/mootools.html
@@ -51,7 +51,8 @@
                     "can/view/live/live_test.js",
                     "can/view/scope/scope_test.js",
                     "can/util/string/string_test.js",
-                    "can/util/attr/attr_test.js", function() {
+                    "can/util/attr/attr_test.js",
+                    "can/view/autorender/autorender_test.js", function() {
                         can.dev.logLevel = 3;
                     });
             });

--- a/test/yui.html
+++ b/test/yui.html
@@ -51,7 +51,8 @@
                     "can/view/live/live_test.js",
                     "can/view/scope/scope_test.js",
                     "can/util/string/string_test.js",
-                    "can/util/attr/attr_test.js", function() {
+                    "can/util/attr/attr_test.js",
+                    "can/view/autorender/autorender_test.js", function() {
                         can.dev.logLevel = 3;
                     });
             });

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -51,7 +51,8 @@
                     "can/view/live/live_test.js",
                     "can/view/scope/scope_test.js",
                     "can/util/string/string_test.js",
-                    "can/util/attr/attr_test.js", function() {
+                    "can/util/attr/attr_test.js",
+                    "can/view/autorender/autorender_test.js", function() {
                         can.dev.logLevel = 3;
                     });
             });

--- a/view/autorender/autorender.js
+++ b/view/autorender/autorender.js
@@ -42,7 +42,7 @@ steal("can/util",function(can){
 		var scope = can.scope(el);
 		
 		can.each(el.attributes||[], function(attr) {
-			setAttr(el, attr, scope);
+			setAttr(el, attr.name, scope);
 		});
 		
 		can.bind.call(el, "attributes", function (ev) {

--- a/view/autorender/autorender_test.js
+++ b/view/autorender/autorender_test.js
@@ -4,8 +4,22 @@ steal("can/test", "steal-qunit", function () {
 		var iframe = document.createElement('iframe');
 		window.removeMyself = function(){
 			delete window.removeMyself;
+			delete window.isReady;
+			delete window.hasError;
 			document.body.removeChild(iframe);
-			QUnit.start();
+			start();
+		};
+		window.hasError = function(error) {
+			ok(false, error.message);
+			window.removeMyself();
+		};
+		window.isReady = function(el, scope) {
+			equal(el.length, 1,"only one my-component");
+			equal(el.html(), "Hello World","template rendered");
+			equal(el[0].className, "inserted","template rendered");
+
+			equal(scope.attr("message"), "Hello World", "Scope correctly setup");
+			window.removeMyself();
 		};
 		document.body.appendChild(iframe);
 		iframe.src = src;
@@ -20,7 +34,7 @@ steal("can/test", "steal-qunit", function () {
 
 	if(window.requirejs) {
 		asyncTest("the basics are able to work for requirejs", function(){
-			makeIframe(can.test.path("view/autorender/tests/requirejs-basics.html?"+Math.random()));
+			makeIframe(can.test.path("../../view/autorender/tests/requirejs-basics.html?"+Math.random()));
 		});
 	}
 

--- a/view/autorender/tests/requirejs-basics.html
+++ b/view/autorender/tests/requirejs-basics.html
@@ -1,5 +1,11 @@
 <script>
-	window.QUnit = window.parent.QUnit;
+	window.isReady = window.parent.isReady || function(el) {
+		console.log(el.length);
+		console.log(el.html());
+	};
+	window.hasError = window.parent.hasError || function(error) {
+		console.log("error in autoload", error)
+	};
 	window.removeMyself = window.parent.removeMyself;
 </script>
 <script type='text/stache' id='basics' can-autorender>
@@ -11,30 +17,13 @@
 	require.config({
 		paths: {
 			"can": "../../../dist/amd/can",
-			"jquery": "../../../node_modules/jquery/dist/jquery.js"
-		},
+			"jquery": "../../../node_modules/jquery/dist/jquery"
+		}
 	});
 
 	require(['can/view/autorender'],function(ready){
-		ready(function(){
-			if(window.QUnit) {
-				QUnit.equal( $("body my-component").length, 1,"only one my-component" );
-				QUnit.equal( $("body my-component").html(), "Hello World","template rendered" );
-				QUnit.equal( $("body my-component")[0].className, "inserted","template rendered" );
-				removeMyself();
-			} else {
-				console.log( $("body my-component").length );
-				console.log( $("body my-component").html() );
-			}
-			
-		}, function(error){
-			if(window.QUnit) {
-				
-				QUnit.ok( false, "error in autoload");
-				removeMyself();
-			} else {
-				console.log("error in autoload", error)
-			}
-		});
+		ready(function() {
+			isReady($("body my-component"), can.scope('my-component'));
+		}, hasError);
 	});
 </script>

--- a/view/autorender/tests/steal-basics.html
+++ b/view/autorender/tests/steal-basics.html
@@ -1,33 +1,22 @@
 <script>
-	window.QUnit = window.parent.QUnit;
+	window.isReady = window.parent.isReady || function(el) {
+		console.log(el.length);
+		console.log(el.html());
+	};
+	window.hasError = window.parent.hasError || function(error) {
+		console.log("error in autoload", error)
+	};
 	window.removeMyself = window.parent.removeMyself;
 </script>
-<script type='text/stache' id='basics' can-autorender>
+<script type='text/stache' id='basics' foo='bar' can-autorender>
 	<can-import from="can/view/autorender/tests/steal-basics"/>
 	<my-component></my-component>
 </script>
 <script src='../../../node_modules/steal/steal.js' main='can/view/autorender/'></script>
 <script>
-	steal('can/view/autorender',function(ready){
-		ready(function(){
-			if(window.QUnit) {
-				QUnit.equal( $("body my-component").length, 1,"only one my-component" );
-				QUnit.equal( $("body my-component").html(), "Hello World","template rendered" );
-				QUnit.equal( $("body my-component")[0].className, "inserted","template rendered" );
-				removeMyself();
-			} else {
-				console.log( $("body my-component").length );
-				console.log( $("body my-component").html() );
-			}
-			
-		}, function(error){
-			if(window.QUnit) {
-				
-				QUnit.ok( false, "error in autoload");
-				removeMyself();
-			} else {
-				console.log("error in autoload", error)
-			}
-		});
+	steal('can', 'can/view/autorender',function(can, ready){
+		ready(function() {
+			isReady($("body my-component"), can.scope('my-component'));
+		}, hasError);
 	});
 </script>


### PR DESCRIPTION
This fixes can.scope and autorender. There were two problems:

1. autorender depended on can.scope to create a scope for an element
when one didn't already exist and this no longer was happening. The fix
was to make can.scope create a scope if there isn't already one. Added a
test for can.scope for this.

2. autorender was setting up scope for the scoped script tag and adding
attributes to the scope but this wasn't working. The reason is that
`el.attributes` is a NamedNodeMap of Attrs which are objects, not
strings. The fix was to use the `attr.name` property.

Fixes #1503