### PR TITLE
Set the context correctly when an async compute has a length of 1

### DIFF
--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -717,5 +717,15 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		
 		equal( async(), 3, "can read unbound");
 	});
-	
+
+	test('compute.async getter has correct when length === 1', function(){
+		var m = new can.Map();
+
+		var getterCompute = can.compute.async(false, function (singleArg) {
+			equal(this, m, 'getter has the right context');
+		}, m);
+
+		getterCompute.bind('change', can.noop);
+	});
+
 });

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -477,7 +477,7 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 				// If it has a single argument, pass it the current value
 				// or the value from define.set.
 				data = setupComputeHandlers(this, function() {
-					return fn.call(settings, lastSetValue.get() );
+					return fn.call(settings.context, lastSetValue.get() );
 				}, settings);
 			} else {
 				// The updater function passed to on so that if called with


### PR DESCRIPTION
While updating our app to 2.2, @imjoshdean and I found a bug that caused a property's `get` method to have the wrong context when an argument was defined. Here's the first breaking test we were able to create: https://github.com/bitovi/canjs/commit/2d0caf4306e902dec638bda0fab56b41ac865a28

This PR fixes the bug and tests the specific aspect of `can.compute` that was causing the problem. 

/cc @justinbmeyer 