### PR TITLE
Renaming and adding can.Component viewModel property.

### DIFF
--- a/component/component.md
+++ b/component/component.md
@@ -9,7 +9,7 @@
 @description Create widgets that use a template, a view-model 
 and custom tags.
 
-@warning {2.1} To pass data from the scope, you must wrap your attribute
+@warning {2.1} To pass data from the viewModel, you must wrap your attribute
 value with `{}`. In 3.0, [can.mustache]
 will use [can.stache]'s method.
 
@@ -23,18 +23,18 @@ property of the component.
 
 @param {String} ATTR-NAME An HTML attribute name. Any attribute name is
 valid. Any attributes added to the element are added as properties to the
-component's [can.Component::scope scope].
+component's [can.Component::viewModel viewModel].
 
 @param {can.mustache.key} [ATTR-VALUE] Specifies the value of a property passed to
-the component instance's [can.Component::scope scope]. By default `ATTR-VALUE`
-values are looked up in the [can.view.Scope can.mustache scope]. If the string value
+the component instance's [can.Component::viewModel viewModel]. By default `ATTR-VALUE`
+values are looked up in the [can.view.viewModel can.mustache viewModel]. If the string value
 of the `ATTR-NAME` is desired, this can be specified like: 
 
     ATTR-NAME: "@"
 
 @param {can.mustache.key} [KEY] Specifies the value of a property passed to
-the component instance's [can.Component::scope scope] that will be looked
-up in the [can.view.Scope can.stache scope]. 
+the component instance's [can.Component::viewModel viewModel] that will be looked
+up in the [can.view.Scope can.stache scope].
 
 @signature `< TAG [ATTR-NAME="{KEY}|ATTR-VALUE"] >`
 
@@ -48,21 +48,21 @@ property of the component.
 
 @param {String} ATTR-NAME An HTML attribute name. Any attribute name is
 valid. Any attributes added to the element are added as properties to the
-component's [can.Component::scope scope]. In the DOM, attribute names
-are case insensitive.  To pass a camelCase attribute to the component's scope,
+component's [can.Component::viewModel viewModel]. In the DOM, attribute names
+are case insensitive.  To pass a camelCase attribute to the component's viewModel,
 hypenate the attribute name like:
 
     <tag attr-name="{key}"></tag>
 
-This will set `attrName` on the component's scope.
+This will set `attrName` on the component's viewModel.
 
 @param {can.stache.key} [KEY] Specifies the value of a property passed to
-the component instance's [can.Component::scope scope] that will be looked
+the component instance's [can.Component::viewModel viewModel] that will be looked
 up in the [can.view.Scope can.stache scope]. 
 
 @param {can.stache.key} [ATTR-VALUE] If the attribute value is not
 wrapped with `{}`, the string value of the attribute will be
-set on the component's scope.
+set on the component's viewModel.
 
 @body
 
@@ -74,13 +74,13 @@ with the methods and properties of how your component behaves:
     can.Component.extend({
       tag: "hello-world",
       template: "{{#if visible}}{{message}}{{else}}Click me{{/if}}",
-      scope: {
+      viewModel: {
         visible: false,
         message: "Hello There!"
       },
       events: {
         click: function(){
-        	this.scope.attr("visible", !this.scope.attr("visible") );
+        	this.viewModel.attr("visible", !this.viewModel.attr("visible") );
         }
       }
     });
@@ -159,13 +159,13 @@ Changes `<hello-world>Hi There</hello-world>` into:
 
     <hello-world><h1>Hi There</h1></hello-world>
 
-### Scope
+### viewModel
 
-A component's [can.Component::scope scope] defines a can.Map that
+A component's [can.Component::viewModel viewModel] defines a can.Map that
 is used to render the component's template. The maps properties 
 are typically set by attributes on the custom element's 
-HTML. By default, every attribute's value is looked up in the parent scope
-of the custom element and added to the scope object.
+HTML. By default, every attribute's value is looked up in the parent viewModel
+of the custom element and added to the viewModel object.
 
 The following component:
 
@@ -190,7 +190,7 @@ Default values can be provided. The following component:
     can.Component.extend({
       tag: "hello-world",
       template: "<h1>{{message}}</h1>",
-      scope: {
+      viewModel: {
         message: "Hi"
       }
     });
@@ -204,13 +204,13 @@ Into:
 
     <hello-world><h1>Hi</h1></hello-world>
 
-If you want to set the string value of the attribute on scope, give scope a 
+If you want to set the string value of the attribute on viewModel, give viewModel a
 default value of "@".  The following component:
 
     can.Component.extend({
       tag: "hello-world",
       template: "<h1>{{message}}</h1>",
-      scope: {
+      viewModel: {
         message: "@"
       }
     });
@@ -235,8 +235,8 @@ adds "!" to the message every time `<hello-world>` is clicked:
       template: "<h1>{{message}}</h1>",
       events: {
         "click" : function(){
-          var currentMessage = this.scope.attr("message");
-          this.scope.attr("message", currentMessage+ "!")
+          var currentMessage = this.viewModel.attr("message");
+          this.viewModel.attr("message", currentMessage+ "!")
         }
       }
     });
@@ -265,7 +265,7 @@ only renders friendly messages:
 
 ## Differences between components in can.mustache and can.stache
 
-A [can.mustache] template passes values from the scope to a `can.Component`
+A [can.mustache] template passes values from the viewModel to a `can.Component`
 by specifying the key of the value in the attribute directly.  For example:
 
     can.Component.extend({
@@ -330,7 +330,7 @@ To add another panel, all we have to do is add data to `foodTypes` like:
 The secret is that the `<panel>` element listens to when it is inserted
 and adds its data to the tabs' list of panels with:
 
-    this.element.parent().scope().addPanel( this.scope );    
+    this.element.parent().viewModel().addPanel( this.viewModel );
 
 ### TreeCombo
 
@@ -338,9 +338,9 @@ The following tree combo lets people walk through a hierarchy and select locatio
 
 @demo can/component/examples/treecombo.html
 
-The secret to this widget is the scope's `breadcrumb` property, which is an array
+The secret to this widget is the viewModel's `breadcrumb` property, which is an array
 of items the user has navigated through, and `selectableItems`, which represents the children of the
-last item in the breadcrub.  These are defined on the scope like:
+last item in the breadcrub.  These are defined on the viewModel like:
 
 
     breadcrumb: [],
@@ -359,7 +359,7 @@ last item in the breadcrub.  These are defined on the scope like:
       }
     }
 
-When the "+" icon is clicked next to each item, the scope's `showChildren` method is called, which
+When the "+" icon is clicked next to each item, the viewModel's `showChildren` method is called, which
 adds that item to the breadcrumb like:
 
     showChildren: function( item, el, ev ) {
@@ -385,7 +385,7 @@ The `app` component creates an instance of the `Paginate` model
 and a `websitesDeferred` that represents a request for the Websites
 that should be displayed.
 
-    scope: function () {
+    viewModel: function () {
       return {
         paginate: new Paginate({
           limit: 5

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -60,7 +60,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 				"{{/panels}}" +
 				"</ul>" +
 				"<content></content>",
-			scope: {
+			viewModel: {
 				panels: [],
 				addPanel: function (panel) {
 
@@ -194,7 +194,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 			tag: "hello-world",
 			leakScope: false,
 			template: can.view.mustache("{{greeting}} <content>World</content>{{exclamation}}"),
-			scope: {greeting: "Hello"}
+			viewModel: {greeting: "Hello"}
 		});
 		var template = can.view.mustache("<hello-world>{{greeting}}</hello-world>");
 		can.append(can.$("#qunit-fixture"), template({
@@ -208,7 +208,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: "hello-world-no-template",
 			leakScope: false,
-			scope: {greeting: "Hello"}
+			viewModel: {greeting: "Hello"}
 		});
 		template = can.view.mustache("<hello-world-no-template>{{greeting}}</hello-world-no-template>");
 		can.append(can.$("#qunit-fixture"), template({
@@ -226,7 +226,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 			tag: "hello-world",
 			leakScope: true,
 			template: can.view.mustache("{{greeting}} <content>World</content>{{exclamation}}"),
-			scope: {greeting: "Hello"}
+			viewModel: {greeting: "Hello"}
 		});
 		var template = can.view.mustache("<hello-world>{{greeting}}</hello-world>");
 		can.append(can.$("#qunit-fixture"), template({
@@ -261,7 +261,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 				"{{/selectableItems}}" +
 				"</content>" +
 				"</ul>",
-			scope: {
+			viewModel: {
 				items: [],
 				breadcrumb: [],
 				selected: [],
@@ -626,7 +626,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: "hello-world",
 			template: "{{#if visible}}{{message}}{{else}}Click me{{/if}}",
-			scope: {
+			viewModel: {
 				visible: false,
 				message: "Hello There!"
 			},
@@ -652,7 +652,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component({
 			"tag": "my-greeting",
 			template: "<h1><content/></h1>",
-			scope: {
+			viewModel: {
 				title: "can.Component"
 			}
 		});
@@ -671,7 +671,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component({
 			tag: "my-taggy-tag",
 			template: "<h1>hello</h1>",
-			scope: {
+			viewModel: {
 				foo: "bar"
 			}
 		});
@@ -703,7 +703,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component({
 			tag: "my-toggler",
 			template: "{{#if visible}}<content/>{{/if}}",
-			scope: {
+			viewModel: {
 				visible: true,
 				show: function () {
 					this.attr('visible', true);
@@ -716,7 +716,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 
 		can.Component({
 			tag: "my-app",
-			scope: {
+			viewModel: {
 				visible: true,
 				show: function () {
 					this.attr('visible', true);
@@ -754,7 +754,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component({
 			tag: 'my-text',
 			template: '<p>{{valueHelper}}</p>',
-			scope: {
+			viewModel: {
 				value: '@'
 			},
 			helpers: {
@@ -778,7 +778,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 	test('access hypenated attributes via camelCase or hypenated', function () {
 		can.Component({
 			tag: 'hyphen',
-			scope: {
+			viewModel: {
 				'camelCase': '@'
 			},
 			template: '<p>{{valueHelper}}</p>',
@@ -809,7 +809,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: 'my-scope',
 			template: "{{name}}}",
-			scope: me
+			viewModel: me
 		});
 
 		var template = can.view.mustache('<my-scope></my-scope>');
@@ -824,7 +824,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: "my-list",
 			template: "{{#each items}}<li><content/></li>{{/each}}",
-			scope: {
+			viewModel: {
 				items: new can.List([{
 					name: "one"
 				}, {
@@ -908,7 +908,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: "my-helloworld",
 			template: "<h1>{{#if visible}}visible{{else}}invisible{{/if}}</h1>",
-			scope: HelloWorldModel
+			viewModel: HelloWorldModel
 		});
 
 		var template = can.view.mustache("<my-helloworld></my-helloworld>");
@@ -982,7 +982,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component({
 			tag: 'child-tag',
 
-			scope: {
+			viewModel: {
 				init: function () {
 					inited++;
 				}
@@ -999,7 +999,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 
 			template: '{{#shown}}<child-tag></child-tag>{{/shown}}',
 
-			scope: {
+			viewModel: {
 				shown: false
 			},
 			events: {
@@ -1025,7 +1025,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 
 		can.Component.extend({
 			tag: "panel",
-			scope: PanelViewModel
+			viewModel: PanelViewModel
 		});
 
 		var frag = can.view.mustache('<panel title="Libraries">Content</panel>')({
@@ -1042,7 +1042,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: "attr-fun",
 			template: "<h1>{{fullName}}</h1>",
-			scope: {
+			viewModel: {
 				firstName: "@",
 				lastName: "@",
 				fullName: function () {
@@ -1074,7 +1074,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 	test("id, class, and dataViewId should be ignored (#694)", function () {
 		can.Component.extend({
 			tag: "stay-classy",
-			scope: {
+			viewModel: {
 				notid: "foo",
 				notclass: 5,
 				notdataviewid: {}
@@ -1113,7 +1113,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: "parent-tag",
 			template: '<child-tag can-click="method"></child-tag>',
-			scope: {
+			viewModel: {
 				method: function () {
 					called = true;
 				}
@@ -1296,14 +1296,14 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 
 		can.Component.extend({
 			tag: "can-parent-stache",
-			scope: {
+			viewModel: {
 				shown: true
 			},
 			template: can.stache("{{#if shown}}<can-child></can-child>{{/if}}")
 		});
 		can.Component.extend({
 			tag: "can-parent-mustache",
-			scope: {
+			viewModel: {
 				shown: true
 			},
 			template: can.mustache("{{#if shown}}<can-child></can-child>{{/if}}")
@@ -1333,7 +1333,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: "foobar",
 			template: "<div>{{name}}</div>",
-			scope: {
+			viewModel: {
 				name: "Brian"
 			}
 		});
@@ -1346,7 +1346,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 		can.Component.extend({
 			tag: 'parent-component',
 			template: can.stache('{{#if shown}}<child-component></child-component>{{/if}}'),
-			scope: {
+			viewModel: {
 				shown: false
 			}
 		});
@@ -1402,7 +1402,7 @@ steal("can/component", "can/view/stache" ,"can/route", "steal-qunit", function (
 
 		can.Component.extend({
 			tag:'my-app',
-			scope: {
+			viewModel: {
 				MyConstruct: Test
 			},
 			events: {

--- a/component/events.md
+++ b/component/events.md
@@ -9,10 +9,10 @@ that handle the event. For example:
     can.Component({
       events: {
         ".next click": function(){
-          this.scope.next()
+          this.viewModel.next()
         }
       },
-      scope: {
+      viewModel: {
         next: function(){
           this.attr("offset", this.offset + this.limit);
         }
@@ -21,7 +21,7 @@ that handle the event. For example:
 
 
 A component's events object is used as the prototype of a [can.Control]. The control gets created on the component's
-element. The component's scope is available within event handlers as `this.scope`. 
+element. The component's viewModel is available within event handlers as `this.viewModel`.
 
 
 @body
@@ -29,19 +29,19 @@ element. The component's scope is available within event handlers as `this.scope
 ## Use
 
 [can.Component]'s events object allows you to provide low-level [can.Control]-like abilities to a `can.Component`
-while still accessing `can.Component`'s objects and methods like [can.Component::scope scope].  The following
-example listens to clicks on elements with `className="next"` and calls `.next()` on the component's scope.
+while still accessing `can.Component`'s objects and methods like [can.Component::viewModel viewModel].  The following
+example listens to clicks on elements with `className="next"` and calls `.next()` on the component's viewModel.
 
 @demo can/component/examples/paginate_events_next.html
 
-The events object can also listen to objects or properties on the component's [can.Component::scope scope]. For instance, instead 
+The events object can also listen to objects or properties on the component's [can.Component::viewModel viewModel]. For instance, instead
 of using live-binding, we could listen to when offset changes and update the page manually:
 
 @demo can/component/examples/paginate_events_next_update_page.html 
 
 ## High performance template rendering
 
-While [can.view.bindings] conveniently allows you to call a [can.Component::scope scope] method from a template like:
+While [can.view.bindings] conveniently allows you to call a [can.Component::viewModel viewModel] method from a template like:
 
     <input can-change="doSomething"/>
     

--- a/component/examples/1.html
+++ b/component/examples/1.html
@@ -10,7 +10,7 @@
 		</table>
 	</script>
 </body>
-<script src="../node_modules/steal/steal.js"></script>
+<script src="../../node_modules/steal/steal.js"></script>
 <script type='text/javascript'>
 steal("can/util", "can/component", "can/util/fixture",
 	 "can/model", "can/view/autoload","can/view/stache",function (can) {

--- a/component/examples/2.html
+++ b/component/examples/2.html
@@ -8,7 +8,7 @@
   {{/websites}}
   </table>
 </script>
-<script src="../node_modules/steal/steal.js"></script>
+<script src="../../node_modules/steal/steal.js"></script>
 <script type='text/javascript'>
 steal("can/util", "can/component", "can/util/fixture",
 	 "can/model", "can/view/autoload",function (can) {

--- a/component/examples/3.html
+++ b/component/examples/3.html
@@ -8,7 +8,7 @@
 	</tr>
   {{/websites}}
 </script>
-<script src="../node_modules/steal/steal.js"></script>
+<script src="../../node_modules/steal/steal.js"></script>
 <script type='text/javascript'>
 steal("can/util", "can/component", "can/map/setter", "can/util/fixture",
 	 "can/model", function (can) {

--- a/component/examples/4.html
+++ b/component/examples/4.html
@@ -61,7 +61,7 @@
      class="next {{#paginate.canNext}}enabled{{/paginate.canNext}}">Next</a>
 </script>
 
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script type='text/javascript'>
 steal("can/util", "can/component", "can/map/setter", "can/util/fixture",
 	 "can/model", function (can) {

--- a/component/examples/accordion.html
+++ b/component/examples/accordion.html
@@ -22,13 +22,13 @@
 <script>
 	DEMO_HTML = document.getElementById("demo").innerHTML
 </script>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script id="demo-source">
 steal("can/component",function(){
 
 can.Component.extend({
 	tag: "accordion",
-	scope: {
+	viewModel: {
 		// Contains a list of all panel scopes within the
 		// tabs element.
 		panels: [],
@@ -80,7 +80,7 @@ can.Component.extend({
 		"<h2 can-click='makeActive'>{{title}}</h2>"+
 		"{{#if active}}<content></content>{{/if}}",
 	tag:"panel",
-	scope: {
+	viewModel: {
 		active: false,
 		title: "@"
 	},

--- a/component/examples/click_me.html
+++ b/component/examples/click_me.html
@@ -1,12 +1,12 @@
 <body>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script type='text/javascript' id="data-source"> 
 steal("can/component", function() {
 
   can.Component.extend({
     tag: "hello-world",
     template: "{{#if visible}}{{message}}{{else}}Click me{{/if}}",
-    scope: {
+    viewModel: {
       visible: false,
       message: "Hello There!"
     },

--- a/component/examples/grid.js
+++ b/component/examples/grid.js
@@ -1,6 +1,6 @@
 can.Component.extend({
 	tag: 'grid',
-	scope: {
+	viewModel: {
 		items: []
 	},
 	template: '<table><tbody><content></content></tbody></table>',

--- a/component/examples/hello-world.html
+++ b/component/examples/hello-world.html
@@ -4,14 +4,14 @@
 	<hello-world></hello-world>
 </script>
 </div>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script id="demo-source">
 steal("can/component",function(){
 	var x = 0;
 can.Component.extend({
   tag: "hello-world",
   template: "{{#if visible}}<b>{{message}}</b>{{else}}<i>Click me</i>{{/if}}",
-  scope: {
+  viewModel: {
     visible: false,
     message: "Hello There!"
   },

--- a/component/examples/list.html
+++ b/component/examples/list.html
@@ -1,6 +1,6 @@
 <body>
 <div id='app'></div>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script type='text/mustache' id='app-template'>
 <todo-app>
 	<todo-list todos="listOfTodos">
@@ -30,7 +30,7 @@ steal("can/component", function() {
 		can.Component.extend({
 		tag: "todo-list",
 		template: can.view("todo-list-template"),
-		scope: {
+		viewModel: {
 			completedTodos: function(){
 				var count = 0;
 				this.attr('todos').each(function(todo){
@@ -55,7 +55,7 @@ steal("can/component", function() {
 	
 	can.Component.extend({
 		tag: "todo-app",
-		scope:{
+		viewModel:{
 			listOfTodos: new can.List([{name: "Take out trash", completed: true},
 							{name: "Mow Lawn", completed: false}])
 		}

--- a/component/examples/my_greeting_full.html
+++ b/component/examples/my_greeting_full.html
@@ -8,14 +8,14 @@
   </header>
 </script>
 
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script>
 steal("can/component",function(){
 	
   can.Component({
     "tag": "my-greeting",
     template: "<h1><content/></h1>",
-    scope: {
+    viewModel: {
       title: "can.Component"
     }
   })

--- a/component/examples/name_editor.html
+++ b/component/examples/name_editor.html
@@ -1,6 +1,6 @@
 <body>
 <div id='out'></div>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 
 
 
@@ -15,7 +15,7 @@ steal("can/component", function() {
 
 	can.Component.extend({
 		tag: "name-editor",
-		scope: {
+		viewModel: {
 			firstPH: "first",
 			lastPH: "last",
 			honorific: function(){

--- a/component/examples/paginate.html
+++ b/component/examples/paginate.html
@@ -65,7 +65,7 @@
     <page-count page='paginate.page' count='paginate.pageCount'></page-count>
   </app>
 </script>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script type='text/javascript'> 
 steal("can/util", "can/component", "can/map/setter", "can/util/fixture",
   "can/model", function (can) {
@@ -134,7 +134,7 @@ var Paginate = can.Map.extend({
 
 can.Component.extend({
   tag: "app",
-  scope: function () {
+  viewModel: function () {
     return {
       paginate: new Paginate({
         limit: 5
@@ -159,7 +159,7 @@ can.Component.extend({
 
 can.Component.extend({
   tag: "grid",
-  scope: {
+  viewModel: {
     items: [],
     waiting: true
   },

--- a/component/examples/paginate_events_next.html
+++ b/component/examples/paginate_events_next.html
@@ -1,12 +1,12 @@
 <body>
 <div id='out'></div>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script type='text/javascript'> 
 steal("can/component", function() {
 
     can.Component.extend({
       tag: "my-paginate",
-      scope: {
+      viewModel: {
         offset: 0,
         limit: 20,
         next: function(){

--- a/component/examples/paginate_events_next_update_page.html
+++ b/component/examples/paginate_events_next_update_page.html
@@ -1,12 +1,12 @@
 <body>
 <div id='out'></div>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script type='text/javascript'> 
 steal("can/component", function() {
 
     can.Component.extend({
       tag: "my-paginate",
-      scope: {
+      viewModel: {
         offset: 0,
         limit: 20,
         next: function(){

--- a/component/examples/paginate_next.html
+++ b/component/examples/paginate_next.html
@@ -1,12 +1,12 @@
 <body>
 <div id='out'></div>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script type='text/javascript'> 
 steal("can/component", function() {
 
     can.Component.extend({
       tag: "my-paginate",
-      scope: {
+      viewModel: {
         offset: 0,
         limit: 20,
         next: function(){

--- a/component/examples/selected.html
+++ b/component/examples/selected.html
@@ -19,7 +19,7 @@
 </script>
 </div>
 
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script>
 	DEMO_HTML = document.getElementById("html").innerHTML;
 </script>
@@ -28,7 +28,7 @@ steal("can/component", function() {
 
   can.Component.extend({
     tag: "my-items",
-    scope: {
+    viewModel: {
       selected: [],
       toggle: function(item){
       	var selected = this.attr('selected'),

--- a/component/examples/tabs.html
+++ b/component/examples/tabs.html
@@ -43,7 +43,7 @@ tabs ul { display: inline-block; }
   </tabs>
 </script>
 </div>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script id="demo-source">
 steal("can/component",function(){
 	
@@ -60,7 +60,7 @@ can.Component.extend({
     		"{{/panels}}"+
     	"</ul>"+
     	"<content></content>",
-	scope: {
+	viewModel: {
 		// Contains a list of all panel scopes within the
 		// tabs element.
 		panels: [],
@@ -110,7 +110,7 @@ can.Component.extend({
 can.Component.extend({
 	template: "{{#if active}}<content></content>{{/if}}",
 	tag:"panel",
-	scope: {
+	viewModel: {
 		active: false,
 		title: "@"
 	},

--- a/component/examples/treecombo.html
+++ b/component/examples/treecombo.html
@@ -60,7 +60,7 @@
     </content>
   </ul>
 </script>
-<script src="../node_modules/steal/steal.js" main="@empty"></script>
+<script src="../../node_modules/steal/steal.js" main="@empty"></script>
 <script type='text/javascript'>
 steal("can/util", "can/component", "can/map/setter", "can/util/fixture",
   "can/model", function (can) {
@@ -68,7 +68,7 @@ steal("can/util", "can/component", "can/map/setter", "can/util/fixture",
 can.Component.extend({
 	tag: "treecombo",
 	template: can.view("tree-combo-stash"),
-	scope: {
+	viewModel: {
 		items: [],
 		breadcrumb: [],
 		selected: [],

--- a/component/extend.md
+++ b/component/extend.md
@@ -23,7 +23,7 @@ dom elements or observable objects the component listens to.
 @option {can.Component.prototype.helpers} [helpers] Specifies mustache helpers
 used to render the component's template.
 
-@option {can.Component.prototype.scope} [scope] Specifies an object
+@option {can.Component.prototype.viewModel} [viewModel] Specifies an object
 that is is used to render the component's template.
 
 @option {can.Component.prototype.tempate} [template] Specifies the template

--- a/component/helpers.md
+++ b/component/helpers.md
@@ -7,7 +7,7 @@ Helper functions used with the component's template.
 
 An object of [can.mustache] helper names and methods. The helpers are only
 available within the component's template and source html. The helper's
-are always called back with `this` as the [can.Component::scope scope].
+are always called back with `this` as the [can.Component::viewModel viewModel].
 
 @body
 

--- a/component/leakscope.md
+++ b/component/leakscope.md
@@ -3,8 +3,8 @@
 
 A component's [can.Component::leakScope leakScope] option controls whether
 the surrounding template where the component is used can directly share
-scope with the component's internal scope. This option defaults to `true`,
-which means `<content>` is able to access internal scope variables on the
+viewModel with the component's internal viewModel. This option defaults to `true`,
+which means `<content>` is able to access internal viewModel variables on the
 component, and the component will be able to use outside variables when
 used on a page.
 
@@ -14,14 +14,14 @@ For example, if the following component is defined:
         tag: "hello-world",
         leakScope: true, // the default value
         template: "{{greeting}} <content></content>{{exclamation}}",
-        scope: { greeting: "Hello" }
+        viewModel: { greeting: "Hello" }
     })
 
 And used like so:
 
     <hello-world>{{greeting}}</hello-world>
 
-With the following data in the surrounding scope:
+With the following data in the surrounding viewModel:
 
     { greeting: "World", exclamation: "!" }
 
@@ -33,9 +33,9 @@ But if `leakScope` is false:
 
     <hello-world>Hello World</hello-world>
 
-Because when the scope isn't leaked, the internal `template` for the
+Because when the viewModel isn't leaked, the internal `template` for the
 component does not see the surrounding binding for `exclamation` or
-`greeting`, and simply uses its internal `scope` to render its
+`greeting`, and simply uses its internal `viewModel` to render its
 template. This also affects where the `{{greeting}}` will be looked up, in
 the light dom.
 

--- a/component/template.md
+++ b/component/template.md
@@ -2,7 +2,7 @@
 @parent can.Component.prototype
 
 Provides a template to render directly within the component's tag. The template is rendered with the
-component's [can.Component::scope scope].  `<content>` elements within the template are replaced by 
+component's [can.Component::viewModel viewModel].  `<content>` elements within the template are replaced by
 the source elements within the component's tag.
 
 @option {String} The string contents of a [can.mustache] template.  For example:
@@ -33,7 +33,7 @@ with the `<content>` tag.
 There are three things to understand about a [can.Component]'s template:
 
  - It is inserted into the component's tag.
- - It is rendered with access to the component instance's scope.
+ - It is rendered with access to the component instance's viewModel.
  - `<content>` tags within the template act as insertion points for the source elements.
 
 The following example demonstrates all three features:
@@ -47,7 +47,7 @@ __can.Component:__
     can.Component({
       "tag": "my-greeting",
       template: "<h1><content/></h1>",
-      scope: {
+      viewModel: {
         title: "can.Component"
       }
     })
@@ -55,7 +55,7 @@ __can.Component:__
 This registers a component for elements like `<my-greeting>`. Its template
 will place an `<h1>` element directly within `<my-greeting>` and put
 the original contents of `<my-greeting>` within the `<h1>`. The component's
-[can.Component::scope scope] adds a title value.
+[can.Component::viewModel viewModel] adds a title value.
 
 __Source template:__
 
@@ -81,7 +81,7 @@ __Source data:__
     })
 
 This is how we render the source template that uses `<my-greeting>`. Notice
-that the template is rendered with `site` in its [can.view.Scope scope].
+that the template is rendered with `site` in its [can.view.viewModel viewModel].
 
 __HTML Result:__
 
@@ -94,7 +94,7 @@ __HTML Result:__
 This is the result of the template transformations.  Notice that the
 content within the original `<my-greeting>` is placed within the `<h1>` 
 tag.  Also, notice that the original content is able to access data from
-the source data and from the component's scope.
+the source data and from the component's viewModel.
  
 The following sections break this down more.
 

--- a/component/view-model.md
+++ b/component/view-model.md
@@ -2,11 +2,20 @@
 @parent can.Component.prototype
 
 Provides or describes a [can.Map] constructor function or `can.Map` instance that will be
+used to retrieve values found in the component's [can.Component::template template].
+
+@deprecated In 2.2 `scope` has been renamed to [can.Component::viewModel] to avoid confusion with [can.view.Scope]. `scope` is still available for backwards compatibility.
+
+
+@property {Object|can.Map|function} can.Component.prototype.viewModel
+@parent can.Component.prototype
+
+Provides or describes a [can.Map] constructor function or `can.Map` instance that will be
 used to retrieve values found in the component's [can.Component::template template]. The map 
 instance is initialized with values specified by the component element's attributes.
 
-@deprecated {2.1} In 2.1, [can.stache] and [can.mustache] pass values to the 
-scope differently. To pass data from the scope, you must wrap your attribute 
+__Node:__ In 2.1, [can.stache] and [can.mustache] pass values to the
+viewModel differently. To pass data from the viewModel, you must wrap your attribute 
 value with `{}`. In 3.0, `can.mustache`
 will use `can.stache`'s syntax.
 
@@ -15,7 +24,7 @@ will use `can.stache`'s syntax.
 
     can.Component.extend({
       tag: "my-paginate",
-      scope: {
+      viewModel: {
         offset: 0,
         limit: 20,
         next: function(){
@@ -24,12 +33,12 @@ will use `can.stache`'s syntax.
       }
     })
 
-Prototype properties that have values of `"@"` are not looked up in the current scope, instead
+Prototype properties that have values of `"@"` are not looked up in the current viewModel, instead
 the literal string value of the relevant attribute is used (like pass by value instead of pass by reference).  For example:
 
     can.Component.extend({
       tag: "my-tag",
-      scope: {
+      viewModel: {
         title: "@"
       },
       template: "<h1>{{title}}</h1>"
@@ -44,7 +53,7 @@ Results in:
     <my-tag><h1>hello</h1></my-tag>
 
 @option {can.Map} A `can.Map` constructor function will be used to create an instance of the observable
-`can.Map` placed at the head of the template's scope.  For example:
+`can.Map` placed at the head of the template's viewModel.  For example:
 
     var Paginate = can.Map.extend({
       offset: 0,
@@ -55,12 +64,12 @@ Results in:
     })
     can.Component.extend({
       tag: "my-paginate",
-      scope: Paginate
+      viewModel: Paginate
     })
     
 
 @option {function} Returns the instance or constructor function of the object that will be added
-to the scope.
+to the viewModel.
 
 @param {Object} attrs An object of values specified by the custom element's attributes. For example,
 a template rendered like:
@@ -73,35 +82,35 @@ Creates an instance of following control:
 
     can.Component.extend({
     	tag: "my-element",
-    	scope: function(attrs){
+    	viewModel: function(attrs){
     	  attrs.title //-> "Justin";
     	  return new can.Map(attrs);
     	}
     })
 
-And calls the scope function with `attrs` like `{title: "Justin"}`.
+And calls the viewModel function with `attrs` like `{title: "Justin"}`.
 
-@param {can.view.Scope} parentScope
+@param {can.view.viewModel} parentviewModel
 
-The scope the custom tag was found within.  By default, any attribute's values will
-be looked up within the current scope, but if you want to add values without needing
+The viewModel the custom tag was found within.  By default, any attribute's values will
+be looked up within the current viewModel, but if you want to add values without needing
 the user to provide an attribute, you can set this up here.  For example:
 
     can.Component.extend({
     	tag: "my-element",
-    	scope: function(attrs, parentScope){
-    	  return new can.Map({title: parentScope.attr('name')});
+    	viewModel: function(attrs, parentviewModel){
+    	  return new can.Map({title: parentviewModel.attr('name')});
     	}
     });
 
-Notice how the attribute's value is looked up in `my-element`'s parent scope.
+Notice how the attribute's value is looked up in `my-element`'s parent viewModel.
 
 @param {HTMLElement} element The element the [can.Component] is going to be placed on. If you want
 to add custom attribute handling, you can do that here.  For example:
 
     can.Component.extend({
     	tag: "my-element",
-    	scope: function(attrs, parentScope, el){
+    	viewModel: function(attrs, parentviewModel, el){
     	  return new can.Map({title: el.getAttribute('title')});
     	}
     });
@@ -112,7 +121,7 @@ to add custom attribute handling, you can do that here.  For example:
  - The prototype of a `can.Map` that will be used to render the component's template.
  
 @option {can.Map} If an instance of `can.Map` is returned, that instance is placed
-on top of the scope and used to render the component's template.
+on top of the viewModel and used to render the component's template.
 
 @option {Object} If a plain JavaScript object is returned, that is used as a prototype
 definition used to extend `can.Map`.  A new instance of the extended Map is created.
@@ -121,14 +130,14 @@ definition used to extend `can.Map`.  A new instance of the extended Map is crea
 
 ## Use
 
-[can.Component]'s scope property is used to define an __object__, typically an instance
+[can.Component]'s viewModel property is used to define an __object__, typically an instance
 of a [can.Map], that will be used to render the component's 
 template. This is most easily understood with an example.  The following
 component shows the current page number based off a `limit` and `offset` value:
 
     can.Component.extend({
       tag: "my-paginate",
-      scope: {
+      viewModel: {
         offset: 0,
         limit: 20,
         page: function(){
@@ -147,7 +156,7 @@ It would result in:
 
     <my-paginate>Page 1</my-paginate>
     
-This is because the provided scope object is used to extend a can.Map like:
+This is because the provided viewModel object is used to extend a can.Map like:
 
     CustomMap = can.Map.extend({
       offset: 0,
@@ -165,22 +174,22 @@ Next, a new instance of CustomMap is created with the attribute data within `<my
 
     componentData = new CustomMap(attrs);
     
-And finally, that data is added to the `parentScope` of the component, used to 
+And finally, that data is added to the `parentviewModel` of the component, used to 
 render the component's template, and inserted into the element:
 
-    var newScope = parentScope.add(componentData),
-        result = can.mustache("Page {{page}}.")(newScope);
+    var newviewModel = parentviewModel.add(componentData),
+        result = can.mustache("Page {{page}}.")(newviewModel);
     $(element).html(result);
 
 ## Values passed from attributes
 
-Values can be "passed" into the scope of a component, similar to passing arguments into a function. By default, 
+Values can be "passed" into the viewModel of a component, similar to passing arguments into a function. By default, 
 custom tag attributes (other than `class` and `id`) are looked up
-in the parent scope and set as observable values on the [can.Map] instance. 
+in the parent viewModel and set as observable values on the [can.Map] instance. 
 
 Values passed in this way are passed similar to function arguments that are "pass by reference" because they are crossbound to 
-the property in the parent scope. Changes in the parent scope property that is passed in trigger changes in this component's scope 
-property, and likewise, changes in the component's scope property trigger a change in the parent scope property.
+the property in the parent viewModel. Changes in the parent viewModel property that is passed in trigger changes in this component's viewModel 
+property, and likewise, changes in the component's viewModel property trigger a change in the parent viewModel property.
 
 As mentioned in the deprecation warning above, using [can.stache], values are passed into components like this:
 
@@ -203,7 +212,7 @@ The following component requires an `offset` and `limit`:
 
     can.Component.extend({
       tag: "my-paginate",
-      scope: {
+      viewModel: {
         page: function(){
           return Math.floor(this.attr('offset') / this.attr('limit')) + 1;
         }
@@ -235,22 +244,22 @@ index like:
 ### Using attribute values
 
 You can also pass a literal string value of the attribute instead of the attribute's value looked up in
-the parent scope (similar to pass by value). 
+the parent viewModel (similar to pass by value). 
 
-To do this in [can.stache], simply pass any value not wrapped in single brackets, and the scope property will
+To do this in [can.stache], simply pass any value not wrapped in single brackets, and the viewModel property will
 be initialized to this string value:
 
     <my-tag title="hello"></my-tag>
 
-The above will create a title property in the component's scope, which has a string `hello`.  If instead hello was wrapped with
-brackets like `{hello}`, a hello property would be looked up in the parent's scope.
+The above will create a title property in the component's viewModel, which has a string `hello`.  If instead hello was wrapped with
+brackets like `{hello}`, a hello property would be looked up in the parent's viewModel.
 
-To do this in [can.mustache], pass a value like in `can.stache`, and set the corresponding scope property in the component
+To do this in [can.mustache], pass a value like in `can.stache`, and set the corresponding viewModel property in the component
 to `@`.  For example:
 
     can.Component.extend({
       tag: "my-tag",
-      scope: {
+      viewModel: {
         title: "@"
       },
       template: "<h1>{{title}}</h1>"
@@ -266,7 +275,7 @@ Results in:
 
 In 3.0, `can.mustache` syntax (requiring `"@"`) will change to `can.stache`'s (not requiring `"@"`).
 
-If the tag's `title` attribute is changed, it updates the scope property 
+If the tag's `title` attribute is changed, it updates the viewModel property 
 automatically.  This can be seen in the following example:
 
 @demo can/component/examples/accordion.html
@@ -279,15 +288,15 @@ Clicking the __Change title__ button sets a `<panel>` element's `title` attribut
     });
 
 
-## Calling methods on scope from events within the template
+## Calling methods on viewModel from events within the template
 
-Using html attributes like `can-EVENT-METHOD`, you can directly call a scope method
+Using html attributes like `can-EVENT-METHOD`, you can directly call a viewModel method
 from a template. For example, we can make `<my-paginate>` elements include a next
-button that calls the scope's `next` method like:
+button that calls the viewModel's `next` method like:
 
     can.Component.extend({
       tag: "my-paginate",
-      scope: {
+      viewModel: {
         offset: 0,
         limit: 20,
         next: function(context, el, ev){
@@ -300,7 +309,7 @@ button that calls the scope's `next` method like:
       template: "Page {{page}} <button can-click='next'>Next</button>"
     })
 
-Scope methods get called back with the current context, the element that you are listening to
+viewModel methods get called back with the current context, the element that you are listening to
 and the event that triggered the callback.
 
 @demo can/component/examples/paginate_next.html

--- a/guides/components.md
+++ b/guides/components.md
@@ -11,7 +11,7 @@ Create a component constructor function by
 
     can.Component.extend({
       tag: "my-element",
-      scope: {
+      viewModel: {
         visible: true,
         toggle: function(){
           this.attr("visible", !this.attr("visible") )
@@ -41,8 +41,8 @@ Where:
 
  - [tag](../docs/can.Component.prototype.tag.html) - Specifies the HTML element that 
    components are created on.
- - [scope](../docs/can.Component.prototype.scope.html) - Describes a [can.Map](../docs/can.Map.html) that
-   is added to the scope used to render the component's template.
+ - [viewModel](../docs/can.Component.prototype.viewModel.html) - Describes a [can.Map](../docs/can.Map.html) that
+   is added to the viewModel used to render the component's template.
  - [template](../docs/can.Component.prototype.template.html) - A template who's content
    gets inserted within the component's element.
  - [helpers](../docs/can.Component.prototype.helpers.html) - Local mustache helpers
@@ -136,13 +136,13 @@ same [can.view.Scope scope] as the scope where the custom element is
 found within the source template. But, you can adjust the 
 scope with can.Component's scope property.
 
-## Scope 
+## ViewModel
 
-A template's [scope](../docs/can.Component.prototype.scope.html) property 
-allows you to adjust the scope used to render the component's 
+A template's [viewModel](../docs/can.Component.prototype.viewModel.html) property
+allows you to adjust the viewModel used to render the component's
 template.  If a plain JavaScript object is used, that object is used
 to extend and create an instance of [can.Map](../docs/can.Map.html) and
-add to the top to the scope used to render the template.
+add to the top to the viewModel used to render the template.
 
 For example, we can add a visible property to control if the input element
 is visible or not:
@@ -152,16 +152,16 @@ is visible or not:
       template: "<form>Editor: "+
                   "{{#if visible}}<input type='text'/>{{/if}}"+
                 "</form>",
-      scope: {
+      viewModel: {
         visible: true
       }
     })
 
-### Scope bindings
+### ViewModel bindings
 
 This isn't interesting without a way to change toggling the 
 visible property. We can tell our template to call a `toggle` method
-on the scope anytime someone clicks the form 
+on the viewModel anytime someone clicks the form
 with [template bindings](../docs/can.view.bindings.html) like:
 
     can.Component.extend({
@@ -169,7 +169,7 @@ with [template bindings](../docs/can.view.bindings.html) like:
       template: "<form can-click='toggle'>Editor: "+
                   "{{#if visible}}<input type='text'/>{{/if}}"+
                 "</form>",
-      scope: {
+      viewModel: {
         visible: true,
         toggle: function(context, el, ev){
           this.attr("visible", !this.attr("visible") )
@@ -181,19 +181,19 @@ Check it out here:
 
 @demo can/guides/components/scope-0.html
 
-When bindings are used like this, the scope function is called back with
+When bindings are used like this, the viewModel function is called back with
 the element's context, the element, and the event.
 
-### Scope value functions
+### ViewModel value functions
 
-Scope functions can also be called for their value. For example:
+viewModel functions can also be called for their value. For example:
 
     can.Component.extend({
       tag: "todos-editor",
       template: "<form can-click='toggle'>{{visibility}}: "+
                   "{{#if visible}}<input type='text'/>{{/if}}"+
                 "</form>",
-      scope: {
+      viewModel: {
         visible: true,
         toggle: function(context, el, ev){
           this.attr("visible", !this.attr("visible") )
@@ -207,10 +207,10 @@ Scope functions can also be called for their value. For example:
 
 @demo can/guides/components/scope-1.html
 
-### Scope as a can.Map constructor function
+### ViewModel as a can.Map constructor function
 
-The scope object can also be defined as a can.Map constructor function.  This
-makes it easier to test the scope object independent of the component's 
+The viewModel object can also be defined as a can.Map constructor function.  This
+makes it easier to test the viewModel object independent of the component's
 rendering.  For example:
 
     
@@ -230,7 +230,7 @@ rendering.  For example:
       template: "<form can-click='toggle'>{{visibility}}: "+
                   "{{#if visible}}<input type='text'/>{{/if}}"+
                 "</form>",
-      scope: TodosEditorState
+      viewModel: TodosEditorState
     })
 
     // TEST CODE
@@ -240,7 +240,7 @@ rendering.  For example:
     editor.toggle();
     equal( editor.visibility(), "invisible" );
     
-### Passing values to a component's scope
+### Passing values to a component's viewModel
     
 Often, you want to pass values to a component.  This is done by 
 setting attributes on the component's element. For example,
@@ -257,7 +257,7 @@ template.  To do this, add a `todo='mytodo'` attribute.
       template: "{{#if todo}}"+
                   "<input type='text' can-value='todo.name'/>"+
                 "{{/if}}",
-      scope: {}
+      viewModel: {}
     })
 
     var frag = template({
@@ -273,7 +273,7 @@ todo's name.
 @demo can/guides/components/scope-2.html
 
 Sometimes, you want to specify attribute values that are not looked up in the 
-scope.  For example, you might want to give `todos-editor` placeholder text as follows:
+viewModel.  For example, you might want to give `todos-editor` placeholder text as follows:
 
     var template = can.mustache(
                      "<h1>Todo: {{mytodo.name}}</h1>"+
@@ -282,7 +282,7 @@ scope.  For example, you might want to give `todos-editor` placeholder text as f
                     "</todos-editor>")
 
 We can modify the component to read the string placeholder value by setting
-`placeholder` in the scope to "@".  This is a special flag that indicates to 
+`placeholder` in the viewModel to "@".  This is a special flag that indicates to
 simply use the attribute's value.
 
     can.Component.extend({
@@ -292,7 +292,7 @@ simply use the attribute's value.
                          "placeholder='{{placeholder}}' "+
                          "can-value='todo.name'/>"+
                 "{{/if}}",
-      scope: {
+      viewModel: {
         placeholder: "@"
       }
     })
@@ -320,7 +320,7 @@ helper that is used to set the className on a todo's `<li>` element:
     		    "</li>"+
     		  "{{/each}}"+
     		"</ul>",
-    	scope: {
+    	viewModel: {
     		todos: new Todo.List({}),
     		select: function(todo){
     			can.route.attr("id",todo.attr("id"))
@@ -336,7 +336,7 @@ helper that is used to set the className on a todo's `<li>` element:
     });
 
 Notice that `options.context` is used to retrieve the todo because
-`this` within `todoClass` is the scope.
+`this` within `todoClass` is the viewModel.
 
 @demo can/guides/components/helpers-0.html
 
@@ -344,29 +344,29 @@ Notice that `options.context` is used to retrieve the todo because
 ## Events
 
 A component's [events](../docs/can.Component.prototype.events.html) object is 
-used to create a [can.Control] that has access to scope as 
-`this.scope`.  Use it to listen to events safely.
+used to create a [can.Control] that has access to viewModel as
+`this.viewModel`.  Use it to listen to events safely.
 
 For example, we can create a `todos-app` component that
 manages the high-level state of the application. It listens
 to changes in [can/route](../docs/can.route.html) and
-updates the scope's `todo` property. And, if 
+updates the viewModel's `todo` property. And, if
 a todo is destroyed that matches the route's `id`,
 the route's `id` is removed:
 
     can.Component.extend({
       tag: "todos-app",
-      scope: {
+      viewModel: {
         todo: null
       },
       events: {
         "{can.route} id": function(route, ev, id){
           if(id){
             Todo.findOne({id: id}, $.proxy(function(todo){
-              this.scope.attr("todo", todo)
+              this.viewModel.attr("todo", todo)
             }, this))
           } else {
-            this.scope.removeAttr("todo")
+            this.viewModel.removeAttr("todo")
           }
         },
         "{Todo} destroyed": function(Todo, ev, destroyedTodo){
@@ -378,7 +378,7 @@ the route's `id` is removed:
     })
 
 
-You can use templated event binding to listen to changes in scope 
+You can use templated event binding to listen to changes in viewModel
 objects.  Adding the following to `todo-app`'s events object
 listens to todo changes and saves the changes.
 

--- a/guides/ejs.md
+++ b/guides/ejs.md
@@ -61,7 +61,7 @@ almost any JavaScript code is valid in `<% %>`, EJS is incredibly powerful.
 
 Due to constraints necessary for live binding to function, it is heavily
 encouraged to only have one line of JS code per pair of EJS tags in order to
-ensure that the correct scope is maintained.
+ensure that the correct viewModel is maintained.
 
 @codestart
 <% if(todos.attr('length') > 0) { %>

--- a/guides/observables.md
+++ b/guides/observables.md
@@ -15,7 +15,7 @@ three forms of observables:
 
 can.Map and can.List are often extended to create observable types. 
 [Models](../docs/can.Model.html) and [can.route](../docs/can.route.html) are
-based on can.Map, and can.Component's [scope](../docs/can.Component.prototype.scope.html) is a 
+based on can.Map, and can.Component's [viewModel](../docs/can.Component.prototype.view-model.html) is a
 can.Map, but observables are useful on their own too.
 
 To create a Map, call `new can.Map(obj)`. This will give you a map

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -209,10 +209,12 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 
 				var args = [];
 				var $el = can.$(this);
+				var viewModel = can.viewModel($el[0]);
 				var localScope = data.scope.add({
 					"@element": $el,
 					"@event": ev,
-					"@scope": can.scope($el[0]),
+					"@viewModel": viewModel,
+					"@scope": viewModel,
 					"@context": data.scope._context
 				});
 

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -53,14 +53,14 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			});
 			template = can.view.mustache("<div>" +
 			"{{#each foodTypes}}" +
-			"<can-event-args-tester class='with-args' can-click='{withArgs @event @element @scope @scope.test . title content=content}'/>" +
+			"<can-event-args-tester class='with-args' can-click='{withArgs @event @element @viewModel @viewModel.test . title content=content}'/>" +
 			"{{/each}}" +
 			"</div>");
 			function withArgs(ev1, el1, compScope, testVal, context, title, hash) {
 				ok(true, "withArgs called");
 				equal(el1[0].nodeName.toLowerCase(), "can-event-args-tester", "@element is the event's DOM element");
 				equal(ev1.type, "click", "@event is the click event");
-				equal(scope, compScope, "Component scope accessible through @scope");
+				equal(scope, compScope, "Component scope accessible through @viewModel");
 				equal(testVal, scope.attr("test"), "Attributes accessible");
 				equal(context.title, foodTypes[0].title, "Context passed in");
 				equal(title, foodTypes[0].title, "Title passed in");


### PR DESCRIPTION
This pull request renames the component `scope` to `viewModel` to avoid confusion with `can.view.Scope`. `scope` is still available as a backwards compatible alias. For fully migrating the naming (e.g. in the source code, the data attribute etc.) in 3.0 a full API review and Component refactoring is necessary.

Closes #1300.