### PR TITLE
#1521 define map properties in the same order they're defined

### DIFF
--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -672,10 +672,10 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 					equal(curVal, 20);
 					break;
 				case 2:
-					equal(curVal, 20, "on bind");
+					equal(curVal, 30, "on bind");
 					break;
 				case 3:
-					equal(curVal, 30, "on bind");
+					equal(curVal, 40, "on bind");
 					break;
 			}
 			return curVal+add.get();
@@ -687,9 +687,9 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		
 		async.bind("change", function(){});
 		
-		async.set(20);
-		
 		async.set(30);
+		
+		async.set(40);
 	});
 
 

--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -672,10 +672,10 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 					equal(curVal, 20);
 					break;
 				case 2:
-					equal(curVal, 30, "on bind");
+					equal(curVal, 20, "on bind");
 					break;
 				case 3:
-					equal(curVal, 40, "on bind");
+					equal(curVal, 30, "on bind");
 					break;
 			}
 			return curVal+add.get();
@@ -687,9 +687,9 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		
 		async.bind("change", function(){});
 		
-		async.set(30);
+		async.set(20);
 		
-		async.set(40);
+		async.set(30);
 	});
 
 

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -462,8 +462,12 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 			this.lastSetValue = lastSetValue;
 			this._setUpdates = true;
 			this._set = function(newVal){
+				if(newVal === lastSetValue.get()) {
+					return this.value;
+				}
+
 				// this is the value passed to the fn
-				return lastSetValue.set(newVal);
+				lastSetValue.set(newVal);
 			};
 
 			// make sure get is called with the newVal, but not setter

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -463,7 +463,7 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 			this._setUpdates = true;
 			this._set = function(newVal){
 				// this is the value passed to the fn
-				lastSetValue.set(newVal);
+				return lastSetValue.set(newVal);
 			};
 
 			// make sure get is called with the newVal, but not setter

--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -823,4 +823,26 @@ steal("can/map/define", "can/route", "can/test", "steal-qunit", function () {
 		equal(m.attr('computable'), 1, 'compute2 readable via .attr()');
 	});
 
+	test('value and get (#1521)', function(){
+		var MyMap = can.Map.extend({
+		  define: {
+		    list: {
+		      value: function(){
+		        return new can.List(['test']);
+		      }
+		    },
+		    size: {
+		      value: 1,
+		      get: function(val){
+		        var list = this.attr('list');
+		        var length = list.attr('length');
+		        return val + length;
+		      }
+		    }
+		  }
+		});
+
+		var map = new MyMap();
+		equal(map.attr('size'), 2);
+	});
 });

--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -823,26 +823,30 @@ steal("can/map/define", "can/route", "can/test", "steal-qunit", function () {
 		equal(m.attr('computable'), 1, 'compute2 readable via .attr()');
 	});
 
-	test('value and get (#1521)', function(){
-		var MyMap = can.Map.extend({
-		  define: {
-		    list: {
-		      value: function(){
-		        return new can.List(['test']);
-		      }
-		    },
-		    size: {
-		      value: 1,
-		      get: function(val){
-		        var list = this.attr('list');
-		        var length = list.attr('length');
-		        return val + length;
-		      }
-		    }
-		  }
-		});
+	// The old attributes plugin interferes severly with this test.
+	// TODO remove this condition when taking the plugins out of the main repository
+	if(!can.Map.attributes) {
+		test('value and get (#1521)', function () {
+			var MyMap = can.Map.extend({
+				define: {
+					data: {
+						value: function () {
+							return new can.List(['test']);
+						}
+					},
+					size: {
+						value: 1,
+						get: function (val) {
+							var list = this.attr('data');
+							var length = list.attr('length');
+							return val + length;
+						}
+					}
+				}
+			});
 
-		var map = new MyMap();
-		equal(map.attr('size'), 2);
-	});
+			var map = new MyMap({});
+			equal(map.attr('size'), 2);
+		});
+	}
 });

--- a/test/amd/dojo.html
+++ b/test/amd/dojo.html
@@ -52,7 +52,7 @@
                         "can/map/setter", "can/map/attributes",
                         "can/map/validations", "can/map/backup",
                         "can/map/list", "can/map/define",
-                        "can/map/sort", "can/util/object",
+                        "can/list/sort", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
                         "can/util/string", "can/util/attr",

--- a/test/amd/jquery-2.html
+++ b/test/amd/jquery-2.html
@@ -53,7 +53,7 @@
                         "can/map/setter", "can/map/attributes",
                         "can/map/validations", "can/map/backup",
                         "can/map/list", "can/map/define",
-                        "can/map/sort", "can/control/plugin",
+                        "can/list/sort", "can/control/plugin",
                         "can/view/modifiers", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",

--- a/test/amd/jquery.html
+++ b/test/amd/jquery.html
@@ -53,7 +53,7 @@
                         "can/map/setter", "can/map/attributes",
                         "can/map/validations", "can/map/backup",
                         "can/map/list", "can/map/define",
-                        "can/map/sort", "can/control/plugin",
+                        "can/list/sort", "can/control/plugin",
                         "can/view/modifiers", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",

--- a/test/amd/mootools.html
+++ b/test/amd/mootools.html
@@ -53,7 +53,7 @@
                         "can/map/setter", "can/map/attributes",
                         "can/map/validations", "can/map/backup",
                         "can/map/list", "can/map/define",
-                        "can/map/sort", "can/util/object",
+                        "can/list/sort", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
                         "can/util/string", "can/util/attr",

--- a/test/amd/yui.html
+++ b/test/amd/yui.html
@@ -53,7 +53,7 @@
                         "can/map/setter", "can/map/attributes",
                         "can/map/validations", "can/map/backup",
                         "can/map/list", "can/map/define",
-                        "can/map/sort", "can/util/object",
+                        "can/list/sort", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
                         "can/util/string", "can/util/attr",

--- a/test/amd/zepto.html
+++ b/test/amd/zepto.html
@@ -53,7 +53,7 @@
                         "can/map/setter", "can/map/attributes",
                         "can/map/validations", "can/map/backup",
                         "can/map/list", "can/map/define",
-                        "can/map/sort", "can/util/object",
+                        "can/list/sort", "can/util/object",
                         "can/util/fixture", "can/view/bindings",
                         "can/view/live", "can/view/scope",
                         "can/util/string", "can/util/attr",


### PR DESCRIPTION
fixes #1521 by enforcing define property ordering

@justinbmeyer and I discussed this afternoon and the root cause was calling the getter for a property that references a default value, but it hadn't been set yet, even though it is before the getter in the property list.