### PR TITLE
cleans up can.Compute.read and adds template-obserbable promises

### DIFF
--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -758,5 +758,33 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		equal(combined(), true);
 	
 	});
+	
+	test("can.Compute.read can read a promise (#179)", function(){
+		
+		var def = new can.Deferred();
+		var map = new can.Map();
+		
+		var c = can.compute(function(){
+			return can.Compute.read({map: map},["map","data","value"]).value;
+		});
+		
+		var calls = 0;
+		c.bind("change", function(ev, newVal, oldVal){
+			calls++;
+			equal(calls, 1, "only one call");
+			equal(newVal, "Something", "new value");
+			equal(oldVal, undefined, "oldVal");
+			start();
+		});
+		
+		map.attr("data", def);
+		
+		setTimeout(function(){
+			def.resolve("Something");
+		},2);
+		
+		stop();
+		
+	});
 
 });

--- a/compute/read.js
+++ b/compute/read.js
@@ -1,0 +1,200 @@
+steal("can/util", function(can){
+	
+	
+	
+	
+	// there are things that you need to evaluate when you get them back as a property read
+	// for example a compute or a function you might need to call to get the next value to 
+	// actually check
+
+	var read = function (parent, reads, options) {
+		options = options || {};
+		var state = {
+			foundObservable: false
+		};
+		
+		// `cur` is the current value.
+		var cur = readValue(parent, 0, reads, options, state),
+			type,
+			// `prev` is the object we are reading from.
+			prev,
+			// `foundObs` did we find an observable.
+			foundObs,
+			readLength = reads.length,
+			i = 0;
+		
+		while( i < readLength ) {
+			prev = cur;
+			// try to read the property
+			for(var r=0, readersLength = read.propertyReaders.length; r < readersLength; r++) {
+				var reader = read.propertyReaders[r];
+				if(reader.test(cur)) {
+					cur = reader.read(cur, reads[i], i, options, state);
+					break; // there can be only one reading of a property
+				}
+			}
+			i = i+1;
+			// read the value if it is a compute or function
+			cur = readValue(cur, i, reads, options, state);
+			type = typeof cur;
+			// early exit if need be
+			if (i < reads.length && (cur === null || type !== 'function' && type !== 'object')) {
+				if (options.earlyExit) {
+					options.earlyExit(prev, i - 1, cur);
+				}
+				// return undefined so we know this isn't the right value
+				return {
+					value: undefined,
+					parent: prev
+				};
+			}
+			
+		}
+		
+		
+		// handle an ending function
+		// unless it is a can.Construct-derived constructor
+		if (typeof cur === 'function' && !(can.Construct && cur.prototype instanceof can.Construct) && !(can.route && cur === can.route)) {
+			if (options.isArgument) {
+				if (!cur.isComputed && options.proxyMethods !== false) {
+					cur = can.proxy(cur, prev);
+				}
+			} else {
+				if (cur.isComputed && !foundObs && options.foundObservable) {
+					options.foundObservable(cur, i);
+				}
+				cur = cur.call(prev);
+			}
+		}
+		// if we don't have a value, exit early.
+		if (cur === undefined) {
+			if (options.earlyExit) {
+				options.earlyExit(prev, i - 1);
+			}
+		}
+		return {
+			value: cur,
+			parent: prev
+		};
+	};
+	
+	var readValue = function(value, index, reads, options, state){
+		for(var i =0, len = read.valueReaders.length; i < len; i++){
+			if( read.valueReaders[i].test(value, index, reads, options) ) {
+				value = read.valueReaders[i].read(value, index, reads, options, state);
+			}
+		}
+		return value;
+	};
+	// value readers check the current value
+	// and get a new value from it
+	// ideally they would keep calling until 
+	// none of these passed
+	read.valueReaders = [{
+		// compute value reader
+		test: function(value, i, reads, options){
+			return value && value.isComputed && (!options.isArgument && i < reads.length );
+		},
+		read: function(value, i, reads, options, state){
+			if (!state.foundObservable && options.foundObservable) {
+				options.foundObservable(value, i);
+				state.foundObservable = true;
+			}
+			return value instanceof can.Compute ? value.get() : value();
+		}
+	},{
+		// if this is a function before the last read and its not a constructor function
+		test: function(value, i, reads, options){
+			var type = typeof value;
+			// i = reads.length if this is the last iteration of the read for-loop.
+			return i < reads.length  && 
+				type === 'function' && 
+				options.executeAnonymousFunctions &&
+				 !(can.Construct && value.prototype instanceof can.Construct);
+		},
+		read: function(value){
+			return value();
+		}
+	}];
+	
+	// propertyReaders actually read a property value 
+	read.propertyReaders = [
+		// read a can.Map or can.route
+		{
+			test: can.isMapLike,
+			read: function(value, prop, index, options, state){
+				if (!state.foundObservable && options.foundObservable) {
+					options.foundObservable(value, index);
+					state.foundObservable = true;
+				}
+				if (typeof value[prop] === 'function' && value.constructor.prototype[prop] === value[prop]) {
+					// call that method
+					if (options.returnObserveMethods) {
+						return value[prop];
+					// if the property value is a can.Construct
+					} else if ( (prop === 'constructor' && value instanceof can.Construct) ||
+						(value[prop].prototype instanceof can.Construct)) {
+						return value[prop];
+					} else {
+						return value[prop].apply(value, options.args || []);
+					}
+				} else {
+					// use attr to get that value
+					return value.attr(prop);
+				}
+			}
+		},
+		// read a promise
+		{
+			test: can.isPromise,
+			read: function(value, prop, index, options, state){
+				if (!state.foundObservable && options.foundObservable) {
+					options.foundObservable(value, index);
+					state.foundObservable = true;
+				}
+				var observeData = value.__observeData;
+				if(!value.__observeData) {
+					var observeData = value.__observeData = {
+						isPending: true,
+						state: "pending",
+						isResolved: false,
+						isRejected: false
+					};
+					// proto based would be faster
+					can.simpleExtend(observeData, can.event);
+					value.then(function(value){
+						observeData.isPending = false;
+						observeData.isResolved = true;
+						observeData.value = value;
+						observeData.state = "resolved";
+						observeData.dispatch("state",["resolved","pending"]);
+					}, function(reason){
+						observeData.isPending = false;
+						observeData.isRejected = true;
+						observeData.reason = reason;
+						observeData.state = "rejected";
+						observeData.dispatch("state",["rejected","pending"]);
+					});
+				} 
+				can.__reading(observeData,"state");
+				return observeData[prop];
+			}
+		},
+		
+		// read a normal object
+		{
+			// this is the default
+			test: function(){return true;},
+			read: function(value, prop){
+				if(value == null) {
+					return undefined;
+				} else {
+					return value[prop];
+				}
+			}
+		}
+	];
+	
+	
+	return read;
+});

--- a/compute/read.js
+++ b/compute/read.js
@@ -107,10 +107,10 @@ steal("can/util", function(can){
 		test: function(value, i, reads, options){
 			var type = typeof value;
 			// i = reads.length if this is the last iteration of the read for-loop.
-			return i < reads.length  && 
-				type === 'function' && 
+			return i < reads.length  &&
+				type === 'function' &&
 				options.executeAnonymousFunctions &&
-				 !(can.Construct && value.prototype instanceof can.Construct);
+				!(can.Construct && value.prototype instanceof can.Construct);
 		},
 		read: function(value){
 			return value();
@@ -146,7 +146,9 @@ steal("can/util", function(can){
 		},
 		// read a promise
 		{
-			test: can.isPromise,
+			test: function(value){
+				return can.isPromise(value);
+			},
 			read: function(value, prop, index, options, state){
 				if (!state.foundObservable && options.foundObservable) {
 					options.foundObservable(value, index);
@@ -154,7 +156,7 @@ steal("can/util", function(can){
 				}
 				var observeData = value.__observeData;
 				if(!value.__observeData) {
-					var observeData = value.__observeData = {
+					observeData = value.__observeData = {
 						isPending: true,
 						state: "pending",
 						isResolved: false,
@@ -175,7 +177,7 @@ steal("can/util", function(can){
 						observeData.state = "rejected";
 						observeData.dispatch("state",["rejected","pending"]);
 					});
-				} 
+				}
 				can.__reading(observeData,"state");
 				return observeData[prop];
 			}

--- a/util/can.js
+++ b/util/can.js
@@ -12,9 +12,12 @@ steal(function () {
 	// An empty function useful for where you need a dummy callback.
 	can.k = function(){};
 
-	can.isDeferred = function (obj) {
+	can.isDeferred = can.isPromise = function (obj) {
 		// Returns `true` if something looks like a deferred.
 		return obj && typeof obj.then === "function" && typeof obj.pipe === "function";
+	};
+	can.isMapLike = function(obj){
+		return can.Map && (obj instanceof can.Map || obj && obj.__get);
 	};
 
 	var cid = 0;

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3720,5 +3720,58 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs","s
 		equal(div.getElementsByTagName("li").length, 1, "li added");
 	});
 	
+	test("promises work (#179)", function(){
+		
+		var template = can.stache(
+			"{{#if promise.isPending}}<span class='pending'></span>{{/if}}"+
+			"{{#if promise.isRejected}}<span class='rejected'>{{promise.reason.message}}</span>{{/if}}"+
+			"{{#if promise.isResolved}}<span class='resolved'>{{promise.value.message}}</span>{{/if}}");
+		
+		var def = new can.Deferred();
+		var data = {
+			promise: def.promise()
+		};
+		
+		var frag = template(data);
+		var div = document.createElement("div");
+		div.appendChild(frag);
+		
+		var spans = div.getElementsByTagName("span");
+		
+		equal(spans.length, 1);
+		equal(spans[0].className, "pending");
+		
+		stop();
+		
+		def.resolve({message: "Hi there"});
+		
+		// better than timeouts would be using can-inserted, but we don't have can/view/bindings
+		setTimeout(function(){
+			equal(spans.length, 1);
+			equal(spans[0].className, "resolved");
+			equal(spans[0].innerHTML, "Hi there");
+			
+			
+			var def = new can.Deferred();
+			var data = {
+				promise: def.promise()
+			};
+			var frag = template(data);
+			var div = document.createElement("div");
+			div.appendChild(frag);
+			spans = div.getElementsByTagName("span");
+			
+			def.reject({message: "BORKED"});
+			
+			setTimeout(function(){
+				equal(spans.length, 1);
+				equal(spans[0].className, "rejected");
+				equal(spans[0].innerHTML, "BORKED");
+				
+				start();
+			}, 30);
+		},30);
+		
+	});
 	
 });


### PR DESCRIPTION
For #179, this makes promises observable when read by `can.Compute.read`.  

## Promises in the template.

This powers promises in the template like:

```
{{#if promise.isPending}}<span class='pending'></span>{{/if}}
{{#if promise.isRejected}}<span class='rejected'>{{promise.reason.message}}</span>{{/if}}
{{#if promise.isResolved}}<span class='resolved'>{{promise.value.message}}</span>{{/if}}
```

This should work with any promise that passes can.isPromise.  Currently, only objects with `.then` and `.pipe` are considered promises.  Users can overwrite this to be more permissive.

The following properties on a promise are available:

 - isPending
 - isResolved
 - isRejected
 - value - the resolved value of the promise, only available if `isResolved` is `true`.
 - reason - the rejected value, only available if `isRejected` is `true`
 - state - "pending", "resolved", or "rejected"

This only makes promises observable in a template.  If you were to use a promise in a compute, it will not re-evaluate the compute when the promise changes.  However, with async getters and setters, you can wire up changes in the observable state to changes in a value yourself.

## Changes to can.Compute.read

`can.Compute.read` is moved into its own file: _compute/read.js_.  It also is designed to be a bit more extensible.  The read function uses a list of `valueReaders` and `propertyReaders` to read the properties from `parent`.

`valueReaders` are used for things like functions and computes, which do not have a property to read.  

`propertyReaders` are used to read properties on an object, can.Map and now promise.

This change allows us to provide multiple ways to translate the DOT operator into specific ways of reading values for the template.

In the future, I think we should make `can.compute(parent, "foo.bar")` use `can.Compute.read`.  This would allow:

```js
var value = can.compute(map,"promise.value.first.name")
```

where map's "promise" attribute is a promise that returns another map that has a "first" attribute which is a map with a "name" attribute.


