### PR TITLE
Prevents listening to events that happen while reading the compute

### DIFF
--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -727,10 +727,11 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 
 		getterCompute.bind('change', can.noop);
 	});
-	
+
 	test("bug with nested computes and batch ordering (#1519)", function(){
 	
 		var ft = can.compute('a');
+		var other = can.compute(3);
 		
 		var propA = can.compute(function(){
 			return ft() ==='a';
@@ -743,7 +744,7 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		var combined = can.compute(function(){
 			var valA = propA(),
 				valB = propB();
-	
+
 			return valA || valB;
 		});
 		
@@ -751,12 +752,18 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 		
 		combined.bind('change', function(){ });
 		
+		ft.bind('change', function() {
+			can.batch.start();
+			other(2);
+			can.batch.stop();
+		});
+
 		can.batch.start();
 		ft('b');
 		can.batch.stop();
-		
+
 		equal(combined(), true);
-	
+		equal(other(), 2);
 	});
 
 });

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -49,6 +49,11 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 		// Go through what needs to be observed.
 		bindNewSet(oldObserved, newObserveSet, onchanged);
 		unbindOldSet(oldObserved, onchanged);
+		// set ready only after all events that might be caused by a change
+		can.bind.call(info,"ready", function(){
+			info.ready = true;
+		});
+		can.batch.trigger(info,"ready");
 		
 		return info;
 	};
@@ -112,7 +117,7 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 				var self = this;
 				if(!onchanged) {
 					onchanged = function(ev){
-						if (compute.bound && (ev.batchNum === undefined || ev.batchNum !== batchNum) ) {
+						if (readInfo.ready && compute.bound && (ev.batchNum === undefined || ev.batchNum !== batchNum) ) {
 							// Keep the old value
 							var oldValue = readInfo.value;
 							// Get the new value
@@ -150,7 +155,7 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 			on: function(updater){
 				if(!onchanged) {
 					onchanged = function(ev){
-						if (compute.bound && (ev.batchNum === undefined || ev.batchNum !== batchNum) ) {
+						if (readInfo.ready && compute.bound && (ev.batchNum === undefined || ev.batchNum !== batchNum) ) {
 							// Get the new value
 							var reads = can.__clearReading();
 							var newValue = func.call(context);
@@ -380,7 +385,7 @@ steal('can/util', 'can/util/bind', 'can/util/batch', function (can, bind) {
 			else {
 				var self = this;
 				this.onchanged = function(ev) {
-					if (self.bound && (ev.batchNum === undefined || ev.batchNum !== self.batchNum)) {
+					if (self.bound && self.readInfo.ready && (ev.batchNum === undefined || ev.batchNum !== self.batchNum)) {
 						// Keep the old value
 						var oldValue = self.readInfo.value;
 						// Get the new value

--- a/map/map_test.js
+++ b/map/map_test.js
@@ -302,6 +302,28 @@ steal("can/map", "can/compute", "can/test", "can/list", "steal-qunit", function(
 		map.off('undefined_property');
 
 		equal(map._bindings, 1, 'The number of bindings is still correct');
-	})
+	});
 
+	test('Creating map in compute dispatches all events properly', function() {
+		expect(2);
+
+		var source = can.compute(0);
+
+		var c = can.compute(function() {
+			var map = new can.Map();
+			source();
+			map.bind("foo", function(){
+				ok(true);
+			});
+			map.attr({foo: "bar"}); //DISPATCH
+
+			return map;
+		});
+
+		c.bind("change",function(){});
+
+		can.batch.start();
+		source(1);
+		can.batch.stop();
+	});
 });

--- a/util/batch/batch.js
+++ b/util/batch/batch.js
@@ -171,8 +171,12 @@ steal('can/util/can.js', function (can) {
 				transactions--;
 			}
 			if (transactions === 0) {
+				if(currentBatchEvents !== null) {
+					return;
+				}
+
 				currentBatchEvents = batchEvents.slice(0);
-				
+
 				var	callbacks = stopCallbacks.slice(0),
 					i, len;
 				batchEvents = [];
@@ -187,7 +191,7 @@ steal('can/util/can.js', function (can) {
 					can.dispatch.apply(currentBatchEvents[i][0],currentBatchEvents[i][1]);
 				}
 				currentBatchEvents = null;
-				
+
 				for(i = 0, len = callbacks.length; i < callbacks.length; i++) {
 					callbacks[i]();
 				}
@@ -214,18 +218,16 @@ steal('can/util/can.js', function (can) {
 				event = typeof event === 'string' ? {
 					type: event
 				} : event;
-				if (transactions === 0) {
-					if( event.batchNum === can.batch.batchNum && currentBatchEvents) {
-						
-						currentBatchEvents.push([
-							item,
-							[event, args]
-						]);
-						
-					} else {
-						return can.dispatch.call( item, event, args );
-					}
-					
+
+				if( currentBatchEvents) {
+
+					currentBatchEvents.push([
+						item,
+						[event, args]
+					]);
+
+				} else if (transactions === 0) {
+					return can.dispatch.call( item, event, args );
 				} else {
 					event.batchNum = batchNum;
 					batchEvents.push([

--- a/util/batch/batch.js
+++ b/util/batch/batch.js
@@ -8,7 +8,7 @@ steal('can/util/can.js', function (can) {
 		batchEvents = [],
 		stopCallbacks = [],
 		// an array of the currently dispatching batch events ... here so we can add things to the end of it (1519).
-		currentBatchEvents = [];
+		currentBatchEvents = null;
 		
 	can.batch = {
 		/**
@@ -186,7 +186,7 @@ steal('can/util/can.js', function (can) {
 				for(i = 0; i < currentBatchEvents.length; i++) {
 					can.dispatch.apply(currentBatchEvents[i][0],currentBatchEvents[i][1]);
 				}
-				currentBatchEvents = [];
+				currentBatchEvents = null;
 				
 				for(i = 0, len = callbacks.length; i < callbacks.length; i++) {
 					callbacks[i]();
@@ -215,7 +215,7 @@ steal('can/util/can.js', function (can) {
 					type: event
 				} : event;
 				if (transactions === 0) {
-					if( event.batchNum === can.batch.batchNum && currentBatchEvents.length) {
+					if( event.batchNum === can.batch.batchNum && currentBatchEvents) {
 						
 						currentBatchEvents.push([
 							item,


### PR DESCRIPTION
Fixes an infinite loop when reading a compute that also sets attributes in the new batch.