### PR TITLE
Fill array when setting out of bounds elements. Fixes #1548.

### DIFF
--- a/list/list.js
+++ b/list/list.js
@@ -152,8 +152,8 @@ steal("can/util", "can/map", "can/map/bubble.js",function (can, Map, bubble) {
 					prop > this.length - 1) {
 					var newArr = new Array((prop + 1) - this.length);
 					newArr[newArr.length-1] = value;
-					value = newArr;
-					prop = this.length;
+					this.push.apply(this, newArr);
+					return newArr;
 				}
 
 				return can.Map.prototype.__set.call(this, ""+prop, value, current);

--- a/list/list_test.js
+++ b/list/list_test.js
@@ -280,4 +280,12 @@ steal("can/util", "can/list", "can/test", "can/compute", "steal-qunit", function
 		list.shift();
 		ok(true, "No events were fired.");
 	});
+
+	test('setting an index out of bounds does not create an array', function() {
+		expect(1);
+		var l = new can.List();
+
+		l.attr('1', 'foo');
+		equal(l.attr('1'), 'foo');
+	});
 });


### PR DESCRIPTION
Closes #1548