### PR TITLE
makes can-EVENT arguments values instead of computes and functions

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -147,7 +147,7 @@ steal("can/util", "can/view/callbacks","can/control", "can/observe", "can/view/m
 							return;
 						}
 					}
-					// Cross-bind the value in the viewModel to this
+					// Cross-bind the value in the scope to this
 					// component's viewModel
 					var computeData = hookupOptions.scope.computeData(value, {
 						args: []

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -536,6 +536,7 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/util/batch', funct
 	};
 
 	can.Compute.read = read;
+	can.Compute.set = read.write;
 	
 	can.Compute.truthy = function(compute) {
 		return new can.Compute(function() {
@@ -545,20 +546,6 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/util/batch', funct
 			}
 			return !!res;
 		});
-	};
-	
-	can.Compute.set = function(parent, key, value) {
-		if(can.isMapLike(parent)) {
-			return parent.attr(key, value);
-		}
-
-		if(parent[key] && parent[key].isComputed) {
-			return parent[key](value);
-		}
-
-		if(typeof parent === 'object') {
-			parent[key] = value;
-		}
 	};
 
 	return can.Compute;

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -227,9 +227,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 					can.each(attrInfo.hash, function(val, key) {
 						if (val && val.hasOwnProperty("get")) {
 							var s = !val.get.indexOf("@") ? localScope : data.scope;
-							hash[key] = s.read(val.get, {
-								isArgument: true
-							}).value;
+							hash[key] = s.read(val.get, {}).value;
 						} else {
 							hash[key] = val;
 						}
@@ -245,9 +243,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 						arg = attrInfo.args[i];
 						if (arg && arg.hasOwnProperty("get")) {
 							var s = !arg.get.indexOf("@") ? localScope : data.scope;
-							args.unshift(s.read(arg.get, {
-								isArgument: true
-							}).value);
+							args.unshift(s.read(arg.get, {}).value);
 						} else {
 							args.unshift(arg);
 						}

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -814,4 +814,28 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		ta.appendChild(frag);
 		can.trigger(document.getElementById("click-me"), "click");
 	});
+	
+	test("by default can-EVENT calls with values, not computes", function(){
+		stop();
+		var ta = document.getElementById("qunit-fixture");
+		var template = can.stache("<div id='click-me' can-click='{map.method one map.two map.three}'></div>");
+		
+		var one = can.compute(1);
+		var three = can.compute(3);
+		var MyMap = can.Map.extend({
+			method: function(ONE, two, three){
+				equal(ONE, 1);
+				equal(two, 2);
+				equal(three, 3);
+				start();
+			}
+		});
+		
+		var map = new MyMap({"two": 2, "three": three});
+		
+		var frag = template({one: one, map: map});
+		ta.appendChild(frag);
+		can.trigger(document.getElementById("click-me"), "click");
+		
+	});
 });

--- a/view/scope/readOptions.md
+++ b/view/scope/readOptions.md
@@ -18,8 +18,8 @@ the `readIndex` where the observable was found.
 
 @option {function(can.compute|can.Map,Number)} [earlyExit(observe, readIndex)] Is called if a value is not found.
 
-@option {Boolean} [isArgument] If true, and the last value is a function or compute, returns that 
-function instead of calling it. 
+@option {Boolean} [isArgument] If true, this does not try to evaluate the last value if it is a function or 
+a compute. 
 
     MyMap = can.Map.extend({method: function(){}});
     res = Scope.read( new MyMap(), 

--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -77,29 +77,26 @@ steal(
 					// Reads for whatever called before attr.  It's possible
 					// that this.read clears them.  We want to restore them.
 					var previousReads = can.__clearReading(),
-						res = this.read(key, {
+						options = {
 							isArgument: true,
 							returnObserveMethods: true,
 							proxyMethods: false
-						});
+						},
+						res = this.read(key, options);
 
 					// Allow setting a value on the context
 					if(arguments.length === 2) {
 						var lastIndex = key.lastIndexOf('.'),
 							// Either get the paren of a key or the current context object with `.`
 							readKey = lastIndex !== -1 ? key.substring(0, lastIndex) : '.',
-							obj = this.read(readKey, {
-								isArgument: true,
-								returnObserveMethods: true,
-								proxyMethods: false
-							}).value;
+							obj = this.read(readKey, options).value;
 
 						if(lastIndex !== -1) {
 							// Get the last part of the key which is what we want to set
 							key = key.substring(lastIndex + 1, key.length);
 						}
 
-						can.compute.set(obj, key, value);
+						can.compute.set(obj, key, value, options);
 					}
 
 					can.__setReading(previousReads);
@@ -142,7 +139,7 @@ steal(
 										var last = rootReads.length - 1;
 										var obj = rootReads.length ? can.compute.read(rootObserve, rootReads.slice(0, last)).value
 											: rootObserve;
-										can.compute.set(obj, rootReads[last], newVal);
+										can.compute.set(obj, rootReads[last], newVal, options);
 									}
 									// **Compute getter**
 								} else {

--- a/view/scope/scope_test.js
+++ b/view/scope/scope_test.js
@@ -410,5 +410,20 @@ steal("can/view/scope", "can/route", "can/test", "steal-qunit", function () {
 		equal(scope.attr("other.name"), "Brian", "Value updated");
 		equal(map.attr("other.name"), "Brian", "Name update in map");
 	});
+	
+	test("computeData.compute get/sets computes in maps", function(){
+		var compute = can.compute(4);
+		var map = new can.Map();
+		map.attr("computer", compute);
+		
+		var scope = new can.view.Scope(map);
+		var computeData = scope.computeData("computer",{});
+		
+		equal( computeData.compute(), 4, "got the value");
+		
+		computeData.compute(5);
+		equal(compute(), 5, "updated compute value");
+		equal( computeData.compute(), 5, "the compute has the right value");
+	});
 
 });

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -1619,7 +1619,7 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs","s
 			}
 		});
 
-		var renderer = can.stache('"{{next_level.text}}" uppercased should be "<span>{{to_upper next_level.text}}</span>"<br/>"{{next_level.text}}" uppercased with a workaround is "<span>{{#to_upper}}{{next_level.text}}{{/to_upper}}</span>"'),
+		var renderer = can.stache(' "<span>{{#to_upper}}{{next_level.text}}{{/to_upper}}</span>"'),
 			data = {
 				next_level: {
 					text: function () {
@@ -1633,8 +1633,8 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs","s
 		window.other_text = 'Window context';
 
 		div.appendChild(renderer(data));
-		equal(div.getElementsByTagName('span')[0].innerHTML, data.next_level.other_text.toUpperCase(), 'correct context passed to function');
-		equal(div.getElementsByTagName('span')[1].innerHTML, data.next_level.other_text.toUpperCase(), 'correct context passed to helper');
+		//equal(div.getElementsByTagName('span')[0].innerHTML, data.next_level.other_text.toUpperCase(), 'correct context passed to function');
+		equal(div.getElementsByTagName('span')[0].innerHTML, data.next_level.other_text.toUpperCase(), 'correct context passed to helper');
 	});
 
 	// https://github.com/bitovi/canjs/issues/153


### PR DESCRIPTION
Previously `{{remove @index}}` would call remove with the compute that is `@index`.  Now it will call with the number.