### PR TITLE
Keep dev code for the Steal build

### DIFF
--- a/build/config_stealPluginify.js
+++ b/build/config_stealPluginify.js
@@ -189,7 +189,7 @@ module.exports = function(){
 					normalize: canNormalize,
 					minify: true
 				},
-				"steal": {
+				"steal +dev": {
 					graphs: allModuleNames.concat(["can"]),
 					dest: function(moduleName){
 						var name;


### PR DESCRIPTION
Legacy Steal needs the `steal.type` calls in order to use in development
and we had been removing them. Using the `+dev` option leaves these and
other dev warnings you want. Fixes #1577