### PR TITLE
Add standalone tests and fix can.view.autorender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ dist/
 *.orig
 util/can.*.js
 *node_modules*
-standalone*
 docs*
 *.DS_Store
 .idea

--- a/util/can.js
+++ b/util/can.js
@@ -93,7 +93,7 @@ steal(function () {
 	can["import"] = function(moduleName) {
 		var deferred = new can.Deferred();
 		
-		if(typeof window.System === "object") {
+		if(typeof window.System === "object" && can.isFunction(window.System["import"])) {
 			window.System["import"](moduleName).then(can.proxy(deferred.resolve, deferred),
 				can.proxy(deferred.reject, deferred));
 		} else if(window.define && window.define.amd){

--- a/view/autorender/autorender.js
+++ b/view/autorender/autorender.js
@@ -90,14 +90,13 @@ steal("can/util",function(can){
 			can.proxy(deferred.reject, deferred)
 		);
 	}
-	
-	
-	
-	if(document.body){
+
+	if (document.readyState === 'complete') {
 		autoload();
 	} else {
-		can.bind.call(document,"DOMContentLoaded", autoload);
+		can.bind.call(window, 'load', autoload);
 	}
+
 	var promise = deferred.promise();
 	can.autorender = function(success, error){
 		return promise.then(success, error);

--- a/view/autorender/autorender_test.js
+++ b/view/autorender/autorender_test.js
@@ -30,11 +30,13 @@ steal("can/test", "steal-qunit", function () {
 		asyncTest("the basics are able to work for steal", function(){
 			makeIframe(  can.test.path("view/autorender/tests/steal-basics.html?"+Math.random()) );
 		});
-	}
-
-	if(window.requirejs) {
+	} else if(window.requirejs) {
 		asyncTest("the basics are able to work for requirejs", function(){
 			makeIframe(can.test.path("../../view/autorender/tests/requirejs-basics.html?"+Math.random()));
+		});
+	} else {
+		asyncTest("the basics are able to work standalone", function(){
+			makeIframe(can.test.path("view/autorender/tests/standalone-basics.html?"+Math.random()));
 		});
 	}
 

--- a/view/autorender/tests/standalone-basics.html
+++ b/view/autorender/tests/standalone-basics.html
@@ -1,0 +1,26 @@
+<script>
+	window.isReady = window.parent.isReady || function(el) {
+		console.log(el.length);
+		console.log(el.html());
+	};
+	window.hasError = window.parent.hasError || function(error) {
+		console.log("error in autoload", error)
+	};
+	window.removeMyself = window.parent.removeMyself;
+</script>
+<script src="../../../bower_components/jquery/dist/jquery.js"></script>
+<script src="../../../dist/can.jquery.js"></script>
+<script src="../../../dist/can.stache.js"></script>
+<script src="../../../dist/can.autorender.js"></script>
+<script src="standalone-basics.js"></script>
+
+<script type="text/stache" id="basics" foo="bar" can-autorender>
+	<my-component></my-component>
+</script>
+<script>
+	$(function() {
+		can.autorender().then(function() {
+			isReady($("body my-component"), can.viewModel('my-component'));
+		});
+	});
+</script>

--- a/view/autorender/tests/standalone-basics.js
+++ b/view/autorender/tests/standalone-basics.js
@@ -1,0 +1,15 @@
+(function() {
+	window.MyComponent = can.Component.extend({
+		tag: "my-component",
+		// call can.stache b/c it should be imported auto-magically
+		template: can.stache("{{message}}"),
+		scope: {
+			message: "Hello World"
+		},
+		events: {
+			"inserted": function(){
+				this.element[0].className = "inserted";
+			}
+		}
+	});
+})();


### PR DESCRIPTION
Fixes #1582 without being dependent on https://github.com/stealjs/steal/issues/368.