### PR TITLE
Include dev code in steal build

### DIFF
--- a/build/config_stealPluginify.js
+++ b/build/config_stealPluginify.js
@@ -42,7 +42,7 @@ var makeStandaloneAndStealUtil = function(lib){
 			//verbose: true
 		},
 		outputs: {
-			"steal +ignorelibs": {
+			"steal +ignorelibs +dev": {
 				graphs: ["can/util/util"],
 				dest: function(moduleName){
 					moduleName = denpm(moduleName);


### PR DESCRIPTION
Missed this before because can/util is built separately from the other
steal build, so we also need the +dev helper on those builds, otherwise
can/util/can.js won't include it's dev code.

So now with this change I've checked can/view/view.js and
can/util/can.js. Others I should verify?