### PR TITLE
Autorender - Do not denormalize if using Steal

### DIFF
--- a/test/builders/steal-tools/app.js
+++ b/test/builders/steal-tools/app.js
@@ -1,6 +1,7 @@
 import helloworld from "helloworld.stache!stache";
 import helloejs from "hello.ejs!ejs";
 import hellomustache from "hello.mustache!mustache";
+import "can/view/autorender/";
 
 window.MODULE = {
 	ejs: helloejs({message: "Hi"}),

--- a/test/builders/steal-tools/prod-bundled.html
+++ b/test/builders/steal-tools/prod-bundled.html
@@ -1,0 +1,2 @@
+<script src="dist/bundles/app.js"></script>
+<script type="text/stache" can-autorender=""></script>

--- a/view/autorender/autorender.js
+++ b/view/autorender/autorender.js
@@ -65,7 +65,7 @@ steal("can/util",function(can){
 				type = typeInfo && typeInfo[1],
 				typeModule = "can/view/" + type;
 
-			if(!(window.define && window.define.amd)) {
+			if(window.System || !(window.define && window.define.amd)) {
 				typeModule += "/" + type;
 			}
 			


### PR DESCRIPTION
For the AMD build we had to add some denormalization in
can/view/autorender to match the different way modules are written. In
3.0 this won't be a problem as we'll have all of our builds work the
same way.

Since Steal supports window.define when bundled with the build this was
causing a false-negative. Checking for window.System fixes the issue.

Closes #1595