### PR TITLE
Fix AMD build, bring back can/util/library and can/util/can

### DIFF
--- a/build/config_meta_defaults.js
+++ b/build/config_meta_defaults.js
@@ -38,6 +38,10 @@ var reverseNormalize = function(name, load, baseName, baseLoad){
 		return name;
 	}
 
+	if(name === 'util/can') {
+		return 'can/util/can';
+	}
+
 	var parts = name.split("/");
 	if(parts.length > 1) {
 		parts.splice(parts.length-2,1);

--- a/build/config_stealPluginify.js
+++ b/build/config_stealPluginify.js
@@ -251,19 +251,16 @@ module.exports = function(){
 				main: allModuleNames.concat(["can"]),
 				map: {
 					"can/util/util" : "can/util/library"
-				},
-				paths: {
-					"can/util/library": "util/jquery/jquery.js"
 				}
 			},
 			options : {
 				quiet: true
 			},
 			"outputs": {
-				"amd-dev +amddev": {
+				"amd-dev +amddev+ignorelibs": {
 					graphs: allModuleNames.concat(["can"])
 				},
-				"amd +amd": {
+				"amd +amd+ignorelibs": {
 					graphs: allModuleNames.concat(["can"])
 				}
 			}


### PR DESCRIPTION
`can/util/library` was missing and `can/util/can` was built to `can/can` as reported [here](https://gitter.im/bitovi/canjs?at=551c75b805184cd235fba927)