### PR TITLE
allow comporator fn return any negative value

### DIFF
--- a/list/sort/sort.js
+++ b/list/sort/sort.js
@@ -119,7 +119,7 @@ steal('can/util', 'can/list', function () {
 					b = this._getComparatorValue(this.attr(iMin), comparator);
 
 					// [1, 2, 3, 4(b), 9, 6, 3(a)]
-					if (comparatorFn.call(this, a, b) === -1) {
+					if (comparatorFn.call(this, a, b) < 0) {
 						isSorted = false;
 						iMin = i;
 					}
@@ -130,7 +130,7 @@ steal('can/util', 'can/list', function () {
 					// that are improperly sorted.
 					// Note: This is not part of the original selection
 					// sort agortithm
-					if (c && comparatorFn.call(this, a, c) === -1) {
+					if (c && comparatorFn.call(this, a, c) < 0) {
 						isSorted = false;
 					}
 


### PR DESCRIPTION
comporator functions should be allowed to return any value less then zero not only -1