### PR TITLE
Docs: Disambiguating read permissions for leakScope

### DIFF
--- a/component/leakscope.md
+++ b/component/leakscope.md
@@ -4,7 +4,7 @@
 @description Allow reading the outer scope values from a component's template and
 a component's viewModel values in the user content.
 
-@option {Boolean}  `false` only allows reading:
+@option {Boolean}  `false` limits reading to:
  
 - the component's viewModel from the the component's template, and
 - the outer scope values from the user content.


### PR DESCRIPTION
Skimming through this, I read that "false only allows reading" and "true adds the ability to read".  This new wording gives the idea that true's permissions build upon false's.