### PR TITLE
Prevent detached DOM nodes in nested component

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -274,6 +274,7 @@ steal("can/util", "can/view/callbacks","can/control", "can/observe", "can/view/m
 					can.each(handlers, function (handler, prop) {
 						componentScope.unbind(prop, handlers[prop]);
 					});
+					el = null;
 				});
 
 				// ## `events` control
@@ -305,6 +306,7 @@ steal("can/util", "can/view/callbacks","can/control", "can/observe", "can/view/m
 				var nodeList = can.view.nodeLists.register([], undefined, true);
 				teardownFunctions.push(function(){
 					can.view.nodeLists.unregister(nodeList);
+					nodeList = null;
 				});
 
 				// If this component has a template (that we've already converted to a renderer)

--- a/component/examples/nested-component-leak.html
+++ b/component/examples/nested-component-leak.html
@@ -1,0 +1,41 @@
+<div id='out'></div>
+<script src="./node_modules/steal/steal.js"></script>
+<script>
+steal('can/view/stache', 'can/list/sort', 'can/view/bindings', function(){
+
+	var items = [];
+
+	for (var i = 0; i < 1000; i++) {
+		items.push({
+			// Random 5 character String
+			name: Math.random().toString(36)
+				.replace(/[^a-z]+/g, '').substr(0, 5)
+		});
+	}
+
+	can.Component.extend({
+		tag: 'grandparent-component',
+		template: can.stache('' +
+			'<input type="checkbox" can-value="show" />{{#if show}}<parent-component></parent-component>{{/if}}'),
+		scope: {
+			show: false
+		}
+	});
+
+	can.Component.extend({
+		tag: 'parent-component',
+		template: can.stache('<child-component></child-component>')
+	});
+
+	can.Component.extend({
+		tag: 'child-component',
+		template: can.stache('<ul>{{#items}}<li>{{name}}</li>{{/items}}</ul>'),
+		scope: {
+			items: items
+		}
+	});
+
+	$('#out').html(can.stache('<grandparent-component></grandparent-component>'));
+
+});
+</script>


### PR DESCRIPTION
Fixes #1625. 

I would love to include a test, but I couldn't figure out a way to determine the number of detached DOM nodes/or get a heap snapshot from JS. 

![component-leak-fixed](https://cloud.githubusercontent.com/assets/82166/7189726/d263b62c-e44e-11e4-9930-2ef8f2251d6b.gif)

Test used: http://jsfiddle.net/akagomez/ajdj2nu2/