### PR TITLE
#each helper should use it's own NodeList

### DIFF
--- a/view/live/live.js
+++ b/view/live/live.js
@@ -156,6 +156,12 @@ steal('can/util', 'can/view/elements.js', 'can/view', 'can/view/node_lists', 'ca
 				indexMap = [],
 				// True once all previous events have been fired
 				afterPreviousEvents = false,
+				// Indicates that we should not be responding to changes in the list.
+				// It's possible that the compute change causes this list behavior to be torn down.
+				// However that same "change" dispatch will eventually fire the updateList handler because
+				// the list of "change" handlers is copied when dispatching starts.
+				// A 'perfect' fix would be to use linked lists for event handlers.
+				isTornDown = false,
 				// Called when items are added to the list.
 				add = function (ev, items, index) {
 					if (!afterPreviousEvents) {
@@ -324,6 +330,9 @@ steal('can/util', 'can/view/elements.js', 'can/view', 'can/view/node_lists', 'ca
 				},
 				// Called when the list is replaced or setup.
 				updateList = function (ev, newList, oldList) {
+					if(isTornDown) {
+						return;
+					}
 					teardownList();
 					// make an empty list if the compute returns null or undefined
 					list = newList || [];
@@ -346,6 +355,7 @@ steal('can/util', 'can/view/elements.js', 'can/view', 'can/view/node_lists', 'ca
 			parentNode = elements.getParentNode(el, parentNode);
 			// Setup binding and teardown to add and remove events
 			var data = setup(parentNode, function () {
+				// TODO: for stache, binding on the compute is not necessary.
 				if (can.isFunction(compute)) {
 					compute.bind('change', updateList);
 				}
@@ -355,12 +365,16 @@ steal('can/util', 'can/view/elements.js', 'can/view', 'can/view/node_lists', 'ca
 				}
 				teardownList(true);
 			});
+			
 			if(!nodeList) {
 				live.replace(masterNodeList, text, data.teardownCheck);
 			} else {
 				elements.replace(masterNodeList, text);
 				nodeLists.update(masterNodeList, [text]);
-				nodeList.unregistered = data.teardownCheck;
+				nodeList.unregistered = function(){
+					data.teardownCheck();
+					isTornDown = true;
+				};
 			}
 			
 			// run the list setup

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -13,6 +13,7 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 	
 	var helpers = {
 		"each": function(items, options){
+			
 			var resolved = resolve(items),
 				result = [],
 				keys,
@@ -21,6 +22,13 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			
 			if( resolved instanceof can.List ) {
 				return function(el){
+					// make a child nodeList inside the can.view.live.html nodeList
+					// so that if the html is re
+					var nodeList = [el];
+					nodeList.expression = "live.list";
+					can.view.nodeLists.register(nodeList, null, options.nodeList);
+					can.view.nodeLists.update(options.nodeList, [el]);
+					
 					var cb = function (item, index, parentNodeList) {
 								
 						return options.fn(options.scope.add({
@@ -28,7 +36,7 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 							}).add(item), options.options, parentNodeList);
 							
 					};
-					live.list(el, items, cb, options.context, el.parentNode, options.nodeList);
+					live.list(el, items, cb, options.context, el.parentNode, nodeList);
 				};
 			}
 			

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -1,5 +1,5 @@
 /* jshint asi:true,multistr:true*/
-steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs","steal-qunit",function(){
+steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","steal-qunit",function(){
 	
 	
 	QUnit.module("can/view/stache",{
@@ -3918,4 +3918,16 @@ steal("can/view/stache", "can/view","can/test","can/view/mustache/spec/specs","s
 			equal(frag.childNodes[0].namespaceURI, "http://www.w3.org/2000/svg", "svg namespace");
 		});
 	}
+
+	test('using #each when toggling between list and null', function() {
+		var state = new can.Map();
+		var frag = can.stache('{{#each deepness.rows}}<div></div>{{/each}}')(state);
+		
+		state.attr('deepness', {
+			rows: ['test']
+		});
+		state.attr('deepness', null);
+
+		equal(frag.childNodes.length, 1, "only the placeholder textnode");
+	});
 });


### PR DESCRIPTION
This pull request makes sure that the `#each` helper uses its own NodeList for rendering the live list and also makes sure that live lists don't get updated when they have already been torn down.

Closes #1621