### PR TITLE
Fix can.List.prototype.splice when items are similar but not the same

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1598,8 +1598,6 @@ steal("can", "can/map/define", "can/component", "can/view/stache" ,"can/route", 
 
 			can.append(can.$("#qunit-fixture"), can.stache('<grandparent-component></grandparent-component>')());
 
-			console.log(can.view.nodeLists.nodeMap);
-
 			toggle();
 			equal(Object.keys(can.view.nodeLists.nodeMap).length - size, 0,
 				'No new items added to nodeMap');

--- a/list/list.js
+++ b/list/list.js
@@ -308,7 +308,7 @@ steal("can/util", "can/map", "can/map/bubble.js",function (can, Map, bubble) {
 				}
 
 				// if nothing has changed, then return
-				if(allSame) {
+				if(allSame && this.length <= added.length) {
 					return added;
 				}
 

--- a/list/list_test.js
+++ b/list/list_test.js
@@ -288,4 +288,14 @@ steal("can/util", "can/list", "can/test", "can/compute", "steal-qunit", function
 		l.attr('1', 'foo');
 		equal(l.attr('1'), 'foo');
 	});
+
+	test('splice with similar but less items works (#1606)', function() {
+		var list = new can.List([ 'aa', 'bb', 'cc']);
+
+		list.splice(0, list.length, 'aa', 'cc', 'dd');
+		deepEqual(list.attr(), ['aa', 'cc', 'dd']);
+
+		list.splice(0, list.length, 'aa', 'cc');
+		deepEqual(list.attr(), ['aa', 'cc']);
+	});
 });


### PR DESCRIPTION
`can.List.prototype.splice` checks if newly spliced items are the same but does not account for the length of the current and new item array being different so something like

```js
var list = new can.List([ 'aa', 'bb', 'cc']);
list.splice(0, list.length, 'aa', 'bb');
```

Would fail with the list still being `[ 'aa', 'bb', 'cc']`. Closes #1606.