### PR TITLE
Document setting context of Stache data helper

### DIFF
--- a/view/stache/doc/helpers/data.md
+++ b/view/stache/doc/helpers/data.md
@@ -1,6 +1,6 @@
 @function can.stache.helpers.data {{data name}}
 @parent can.stache.htags 7
-@signature `{{data name}}`
+@signature `{{data name[ context]}}`
 
 Adds the current [can.stache.context context] to the
 element's [can.data].
@@ -12,7 +12,7 @@ context.
 
 ## Use
 
-It is common for you to want some data in the template to be available
+It is common to want some data in the template to be available
 on an element.  `{{data name}}` allows you to save the
 context so it can later be retrieved by [can.data] or
 `$.fn.data`. For example,
@@ -20,7 +20,7 @@ context so it can later be retrieved by [can.data] or
 The template:
 
     <ul>
-      <li id="person" {{data 'person'}}>{{name}}</li>
+      <li id="person" {{data 'person'}}>{{person.name}}</li>
     </ul>
 
 Rendered with:
@@ -32,3 +32,25 @@ Retrieve the person data back with:
 
     $("#person").data("person")
 
+### Changing the context
+
+In Stache templates it is possible to explicitly set the context by passing 
+a context as the second argument to the data helper: `{{data name context}}`.
+
+The template:
+
+    <ul>
+      <li id="person" {{data 'person' person2}}>{{person2.name}}</li>
+    </ul>
+
+Rendered with:
+
+    document.body.appendChild(
+      can.stache(template,{ 
+        person: { name: 'Austin' },
+        person2: { name: 'Leah' }
+    );
+
+Retrieve the person data back with:
+
+    $("#person").data("person") // --> { name: 'Leah' )


### PR DESCRIPTION
As mentioned in #1619, this documents setting the context of the data helper explicitly.

Does the "optional argument" syntax work in that @signature?

Closes #1619