### PR TITLE
Allows can-import to be used for dynamic imports

### DIFF
--- a/test/jquery-2.html
+++ b/test/jquery-2.html
@@ -56,6 +56,7 @@
                 "can/util/string/string_test.js",
                 "can/util/attr/attr_test.js",
                 "can/view/autorender/autorender_test.js",
+                "can/view/import/import_test.js"
                 function() {
                     can.dev.logLevel = 3;
                 });

--- a/test/jquery.html
+++ b/test/jquery.html
@@ -54,6 +54,7 @@
                 "can/util/string/string_test.js",
                 "can/util/attr/attr_test.js",
                 "can/view/autorender/autorender_test.js",
+                "can/view/import/import_test.js"
                 function() {
                     can.dev.logLevel = 3;
                 });

--- a/test/mootools.html
+++ b/test/mootools.html
@@ -54,6 +54,7 @@
                 "can/util/string/string_test.js",
                 "can/util/attr/attr_test.js",
                 "can/view/autorender/autorender_test.js",
+                "can/view/import/import_test.js"
                 function() {
                     can.dev.logLevel = 3;
                 });

--- a/test/yui.html
+++ b/test/yui.html
@@ -54,6 +54,7 @@
                 "can/util/string/string_test.js",
                 "can/util/attr/attr_test.js",
                 "can/view/autorender/autorender_test.js",
+                "can/view/import/import_test.js"
                 function() {
                     can.dev.logLevel = 3;
                 });

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -54,6 +54,7 @@
                 "can/util/string/string_test.js",
                 "can/util/attr/attr_test.js",
                 "can/view/autorender/autorender_test.js",
+                "can/view/import/import_test.js"
                 function() {
                     can.dev.logLevel = 3;
                 });

--- a/view/doc/elements_and_attributes.md
+++ b/view/doc/elements_and_attributes.md
@@ -46,3 +46,19 @@ The following functionality is available within plugins:
    <can import from="helpers/stache-helpers"/>
    <my-component> {{myHelper "value"}} </my-component>
    ```
+
+   You can also dynamically import a module and nest content within:
+
+   ```
+   {{#eq page "home"}}
+     <can-import from="components/my-component">
+       {{#eq state "pending"}}
+         <img src="loading.gif"/>
+       {{/eq}}
+
+       {{#eq state "resolved"}}
+         <my-component></my-component>
+       {{/eq}}
+     </can-import>
+   {{/eq}}
+   ```

--- a/view/import/demo/hello.js
+++ b/view/import/demo/hello.js
@@ -1,0 +1,7 @@
+var can = require("can");
+var stache = require("can/view/stache/");
+
+can.Component.extend({
+	tag: "hello-world",
+	template: stache("Hello world!")
+});

--- a/view/import/demo/index.html
+++ b/view/import/demo/index.html
@@ -1,0 +1,40 @@
+<html>
+	<head>
+		<title>&lt;can-import&gt; demo</title>
+	</head>
+	<body>
+		<script type="text/stache" id="template">
+			<div>
+			<button can-click="toggle">Toggle</button>
+			</div>
+
+			{{#if showHello}}
+
+			<can-import from="can/view/import/demo/hello">
+				{{#eq state "pending"}}
+					<span>Loading {{state}}</span>
+				{{/eq}}
+
+				{{#eq state "resolved"}}
+					<hello-world></hello-world>
+				{{/eq}}
+			</can-import>
+
+			{{else}}
+				<span>Lonely in here</span>
+			{{/if}}
+		</script>
+		<script src="../../../node_modules/steal/steal.js" main="@empty">
+			var can = require("can");
+			require("can/view/stache/");
+
+			var renderer = can.view("template");
+			$(document.body).append(renderer(new can.Map({
+				showHello: false,
+				toggle: function(){
+					this.attr("showHello", !this.attr("showHello"));
+				}
+			})));
+		</script>
+	</body>
+</html>

--- a/view/import/import.js
+++ b/view/import/import.js
@@ -1,0 +1,20 @@
+steal("can/util", "can/view/callbacks", function(can){
+
+	can.view.tag("can-import", function(el, tagData){
+		var moduleName = el.getAttribute("from");
+		var importPromise;
+		if(moduleName) {
+			importPromise = window.promise = can["import"](moduleName);
+		} else {
+			importPromise = can.Deferred().reject("No moduleName provided").promise();
+		}
+
+		if(tagData.subtemplate) {
+			var scope = tagData.scope.add(importPromise);
+			var frag = tagData.subtemplate(scope, tagData.options);
+
+			can.appendChild(el, frag);
+		}
+	});
+
+});

--- a/view/import/import_test.js
+++ b/view/import/import_test.js
@@ -1,0 +1,47 @@
+var QUnit = require("steal-qunit");
+var stache = require("can/view/stache/");
+require("can/view/import/");
+var getIntermediateAndImports = require("can/view/stache/intermediate_and_imports");
+
+QUnit.module("can/view/import");
+
+var test = QUnit.test;
+var equal = QUnit.equal;
+
+
+test("static imports are imported", function(){
+	var iai = getIntermediateAndImports("<can-import from='can/view/import/test/hello'/>" +
+		"<hello-world></hello-world>");
+
+	equal(iai.imports.length, 1, "There is one import");
+});
+
+test("dynamic imports are not imported", function(){
+	var iai = getIntermediateAndImports("{{#if a}}<can-import from='can/view/import/test/hello'>" +
+		"<hello-world></hello-world></can-import>{{/if a}}");
+
+	equal(iai.imports.length, 0, "There are no imports");
+});
+
+test("dynamic imports will only load when in scope", function(){
+	expect(4);
+
+	var iai = getIntermediateAndImports("{{#if a}}<can-import from='can/view/import/test/hello'>" +
+		"{{#eq state 'resolved'}}<hello-world></hello-world>{{/eq}}</can-import>{{/if a}}");
+	var template = stache(iai.intermediate);
+
+	var a = can.compute(false);
+	var res = template({ a: a });
+
+	equal(res.childNodes[0].childNodes.length, 0, "There are no child nodes immediately");
+	a(true);
+
+	can["import"]("can/view/import/test/hello").then(function(){
+		equal(res.childNodes[0].childNodes.length, 1, "There is now a nested component");
+		equal(res.childNodes[0].childNodes[0].tagName.toUpperCase(), "HELLO-WORLD", "imported the tag");
+		equal(res.childNodes[0].childNodes[0].childNodes[0].nodeValue, "Hello world!", "text inserted");
+	}).then(QUnit.start);
+
+
+	QUnit.stop();
+});

--- a/view/import/test.html
+++ b/view/import/test.html
@@ -1,0 +1,2 @@
+<title>can-import tests</title>
+<script src="../../node_modules/steal/steal.js" main="can/view/import/import_test"></script>

--- a/view/import/test/hello.js
+++ b/view/import/test/hello.js
@@ -1,0 +1,8 @@
+define(["can"], function(can){
+
+	can.Component.extend({
+		tag: "hello-world",
+		template: "Hello world!"
+	});
+
+});

--- a/view/stache/intermediate_and_imports.js
+++ b/view/stache/intermediate_and_imports.js
@@ -1,54 +1,43 @@
-steal("can/view/stache/mustache_core.js", "can/view/parser",function(mustacheCore, parser){
-	
+steal("can/view/stache/mustache_core.js", "can/view/parser",
+			"can/view/import", function(mustacheCore, parser){
+
 	return function(source){
-		
+
 		var template = mustacheCore.cleanLineEndings(source);
 		var imports = [],
 			inImport = false,
 			inFrom = false;
-		
-		var keepToken = function(){
-			return inImport ? false : true;
-		};
-		
+
 		var intermediate = parser(template, {
 			start: function( tagName, unary ){
 				if(tagName === "can-import") {
 					inImport = true;
-				}
-				return keepToken();
-			},
-			end: function( tagName, unary ){
-				if(tagName === "can-import") {
+				} else if(inImport) {
 					inImport = false;
-					return false;
 				}
-				return keepToken();
 			},
 			attrStart: function( attrName ){
 				if(attrName === "from") {
 					inFrom = true;
 				}
-				return keepToken();
 			},
 			attrEnd:   function( attrName ){
 				if(attrName === "from") {
 					inFrom = false;
 				}
-				return keepToken();
 			},
 			attrValue: function( value ){
 				if(inFrom && inImport) {
 					imports.push(value);
 				}
-				return keepToken();
 			},
-			chars: keepToken,
-			comment: keepToken,
-			special: keepToken,
-			done: keepToken
+			close: function(tagName){
+				if(tagName === "can-import") {
+					imports.pop();
+				}
+			}
 		}, true);
-	    
+
 		return {intermediate: intermediate, imports: imports};
 	};
 


### PR DESCRIPTION
This adds the ability of can-import to be used for dynamic imports. The
static form is still supported, but dynamic imports are allowed by
including a closing `</can-import>` tag and nesting content within.

The viewModel for `can-import` is a Promise that will resolve with a
`value` once the module has been imported.