### PR TITLE
Fixes issue with setter not setting value if setVal not passed

### DIFF
--- a/map/define/define.js
+++ b/map/define/define.js
@@ -155,7 +155,7 @@ steal('can/util', 'can/observe', function (can) {
 			if (getter) {
 				// if there's a getter we don't call old set
 				// instead we call the getter's compute with the new value
-				if(setValue !== undefined && !setterCalled && setter.length >= 2) {
+				if(setValue !== undefined && !setterCalled && setter.length >= 1) {
 					this[prop](setValue);
 				}
 				
@@ -163,7 +163,7 @@ steal('can/util', 'can/observe', function (can) {
 				return;
 			}
 			// if it took a setter and returned nothing, don't set the value
-			else if (setValue === undefined && !setterCalled && setter.length >= 2) {
+			else if (setValue === undefined && !setterCalled && setter.length >= 1) {
 				//!steal-remove-start
 				asyncTimer = setTimeout(function () {
 					can.dev.warn('can/map/setter.js: Setter "' + prop + '" did not return a value or call the setter callback.');

--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -908,4 +908,63 @@ steal("can/map/define", "can/route", "can/test", "steal-qunit", function () {
 			
 		equal(personEvents,2);
 	});
+
+	test('Can read a defined property with a set/get method (#1648)', function () {
+		// Problem: "get" is not passed the correct "lastSetVal"
+		// Problem: Cannot read the value of "foo"
+
+		var Map = can.Map.extend({
+			define: {
+				foo: {
+					value: '',
+					set: function (setVal) {
+						return setVal;
+					},
+					get: function (lastSetVal) {
+						return lastSetVal;
+					}
+				}
+			}
+		});
+
+		var map = new Map();
+
+		equal(map.attr('foo'), '', 'Calling .attr(\'foo\') returned the correct value');
+
+		map.attr('foo', 'baz');
+
+		equal(map.attr('foo'), 'baz', 'Calling .attr(\'foo\') returned the correct value');
+	});
+
+	test('Can bind to a defined property with a set/get method (#1648)', 3, function () {
+		// Problem: "get" is not called before and after the "set"
+		// Problem: Function bound to "foo" is not called
+		// Problem: Cannot read the value of "foo"
+
+		var Map = can.Map.extend({
+			define: {
+				foo: {
+					value: '',
+					set: function (setVal) {
+						return setVal;
+					},
+					get: function (lastSetVal) {
+						return lastSetVal;
+					}
+				}
+			}
+		});
+
+		var map = new Map();
+
+		map.bind('foo', function () {
+			ok(true, 'Bound function is called');
+		});
+		
+		equal(map.attr('foo'), '', 'Calling .attr(\'foo\') returned the correct value');
+
+		map.attr('foo', 'baz');
+
+		equal(map.attr('foo'), 'baz', 'Calling .attr(\'foo\') returned the correct value');
+	});
 });


### PR DESCRIPTION
Fixes #1648.

These tests identified another issue, where assertions in the getter would be called different numbers of times depending on whether the `can.map.attributes` module was included or not. Tests have been refactored to remove these assertions, and a new issue has been opened to address this issue.