### PR TITLE
walking up scope should continue if the scope is a primitive

### DIFF
--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -255,7 +255,9 @@ steal(
 
 					while (scope) {
 						context = scope._context;
-						if (context !== null) {
+						if (context !== null &&
+							// if its a primitive type, keep looking up the scope, since there won't be any properties
+							(typeof context === "object" || typeof context === "function") ) {
 							var data = can.compute.read(context, names, can.simpleExtend({
 								/* Store found observable, incase we want to set it as the rootObserve. */
 								foundObservable: function (observe, nameIndex) {

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3930,4 +3930,21 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		equal(frag.childNodes.length, 1, "only the placeholder textnode");
 	});
+
+
+	test('template with a block section and nested if doesnt render correctly', function() {
+		var myMap = new can.Map({
+			bar: true
+		});
+
+		var frag = can.stache(
+					"{{#bar}}<div>{{#if foo}}My Meals{{else}}My Order{{/if}}</div>{{/bar}}"
+					)(myMap);
+
+		can.append(can.$('#qunit-fixture'), frag);
+		equal(can.$('#qunit-fixture div')[0].innerHTML, 'My Order', 'shows else case');
+		myMap.attr('foo', true);
+		equal(can.$('#qunit-fixture div')[0].innerHTML, 'My Meals', 'shows if case');
+
+	});
 });


### PR DESCRIPTION
fixes #1115 

The test in this PR would work if not wrapped in the {{#bar}} section, which forces the scope to change. However, accessing 'foo' inside this block should still use the parent scope, since 'bar' is a boolean value, not an actual object.

The fix was to make scope.read keep walking up the parents until there's a non-primitive value.