### PR TITLE
Update for steal

### DIFF
--- a/guides/using-loading.md
+++ b/guides/using-loading.md
@@ -243,21 +243,4 @@ With RequireJS and Zepto, it loks like this:
 
 ## StealJS
 
-StealJS is the dependency manager that comes with [JavaScriptMVC](http://javascriptmvc.com) and that is natively used by CanJS.
-Since JavaScriptMVC comes with CanJS and Steal, the easiest way to use them together is by [downloading JavaScriptMVC](http://javascriptmvc.com/dist/javascriptmvc-3.3.zip). You can also use the `steal/` folder from the CanJS download or Bower package.
-
-With the JavaScriptMVC download, in the main folder, you can simply run the application generator:
-
-> ./js jmvc/generate/app app
-
-In `app/app.js` you should see something like:
-
-    steal(
-        './app.less',
-        './models/fixtures/fixtures.js',
-    function(){
-
-    })
-
-This file will be loaded when opening `app/index.html` and you are ready to use CanJS with StealJS and make [using-production production builds].
-For more information follow up in the [JavaScriptMVC documentation](http://javascriptmvc.com/docs).
+See [using CanJS 2.2 with StealJS](http://blog.bitovi.com/using-canjs-2-2-with-stealjs/) for instructions on loading Can with the latest StealJS.


### PR DESCRIPTION
Direct user to CanJS 2.2 with StealJS blog post for instructions. Removed link to JavascriptMVC.