### PR TITLE
Default can.define type helpers handle null and undefined as one would expect

### DIFF
--- a/map/define/define.js
+++ b/map/define/define.js
@@ -204,6 +204,9 @@ steal('can/util', 'can/observe', function (can) {
 			}
 		},
 		'number': function (val) {
+			if(val == null) {
+				return val;
+			}
 			return +(val);
 		},
 		'boolean': function (val) {
@@ -223,6 +226,9 @@ steal('can/util', 'can/observe', function (can) {
 			return val;
 		},
 		'string': function (val) {
+			if(val == null) {
+				return val;
+			}
 			return '' + val;
 		},
 		'compute': {

--- a/map/define/define_test.js
+++ b/map/define/define_test.js
@@ -967,4 +967,66 @@ steal("can/map/define", "can/route", "can/test", "steal-qunit", function () {
 
 		equal(map.attr('foo'), 'baz', 'Calling .attr(\'foo\') returned the correct value');
 	});
+	
+	
+	test("type converters handle null and undefined in expected ways (1693)", function () {
+
+		var Typer = can.Map.extend({
+			define: {
+				date: {  type: 'date' },
+				string: {type: 'string'},
+				number: {  type: 'number' },
+				'boolean': {  type: 'boolean' },
+				htmlbool: {  type: 'htmlbool' },
+				leaveAlone: {  type: '*' }
+			}
+		});
+
+		var t = new Typer().attr({
+			date: undefined,
+			string: undefined,
+			number: undefined,
+			'boolean': undefined,
+			htmlbool: undefined,
+			leaveAlone: undefined
+		});
+
+		equal(t.attr("date"), undefined, "converted to date");
+
+		equal(t.attr("string"), undefined, "converted to string");
+
+		equal(t.attr("number"), undefined, "converted to number");
+
+		equal(t.attr("boolean"), false, "converted to boolean");
+
+		equal(t.attr("htmlbool"), false, "converted to htmlbool");
+
+		equal(t.attr("leaveAlone"), undefined, "left as object");
+		
+		t = new Typer().attr({
+			date: null,
+			string: null,
+			number: null,
+			'boolean': null,
+			htmlbool: null,
+			leaveAlone: null
+		});
+
+		equal(t.attr("date"), null, "converted to date");
+
+		equal(t.attr("string"), null, "converted to string");
+
+		equal(t.attr("number"), null, "converted to number");
+
+		equal(t.attr("boolean"), false, "converted to boolean");
+
+		equal(t.attr("htmlbool"), false, "converted to htmlbool");
+
+		equal(t.attr("leaveAlone"), null, "left as object");
+
+	});
+	
+	
+	
+	
 });

--- a/map/define/doc/type.md
+++ b/map/define/doc/type.md
@@ -12,11 +12,12 @@ Converts a value passed to [can.Map::attr attr] into an appropriate value.
 
 ## Use
 
-The `type` property specifies the type of the attribute.  The type can be specified as either a type function that returns the type coerced value or one of the following strings:
+The `type` property specifies the type of the attribute.  The type can be specified 
+as either a type function that returns the type coerced value or one of the following strings:
 
- - `"string"` - Converts the value to a string.
- - `"date"` - Converts the value to a date or `null if the date can not be converted.
- - `"number"` - Passes the value through `parseFloat`.
+ - `"string"` - Converts the value to a string except `null` or `undefined`.
+ - `"date"` - Converts the value to a date or `null` if the date can not be converted.
+ - `"number"` - Passes the value through `parseFloat` except for `null` or `undefined`.
  - `"boolean"` - Converts falsey, `"false"` or `"0"` to `false` and everything else to true.
  - `"htmlbool"` - Like `boolean`, but also converts empty strings to
    `true`. Used, for example, when input is from component attributes like


### PR DESCRIPTION
For example, setting a "string" type to undefined, will now give you undefined instead of "undefined". Closes #1693