### PR TITLE
Ignore system modules in builds

### DIFF
--- a/build/config_meta_defaults.js
+++ b/build/config_meta_defaults.js
@@ -85,6 +85,10 @@ module.exports = function(){
 				if(load.address.indexOf("node_modules") >= 0) {
 					return true;
 				}
+			}, function(moduleName) {
+					if(moduleName.indexOf('/system') !== -1) {
+						return true;
+					}
 			}])
 		}
 	};


### PR DESCRIPTION
This pull request ignores the SystemJS loader files for the builds since they should not be built. Closes #1684