### PR TITLE
Use Function.prototype.bind if available

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -438,7 +438,6 @@ steal('can/util', 'can/util/bind','./bubble.js', 'can/construct', 'can/util/batc
 					
 					return current && current._get ?  current._get(second) : undefined;
 				} else {
-					console.log(this, attr);
 					can.__observe(this, attr);
 					return this.__get( attr );
 				}

--- a/util/can.js
+++ b/util/can.js
@@ -41,6 +41,15 @@ steal(function () {
 		return arr && arr[arr.length - 1];
 	};
 
+	can.proxy = function (fn, context) {
+		if(Function.prototype.bind) {
+			return fn.bind(context);
+		}
+
+		return function () {
+			return fn.apply(context, arguments);
+		};
+	};
 
 	can.frag = function(item){
 		var frag;

--- a/util/jquery/jquery.js
+++ b/util/jquery/jquery.js
@@ -95,11 +95,7 @@ steal('jquery', 'can/util/can.js', 'can/util/attr', "can/event", 'can/util/array
 			}
 			return this;
 		},
-		proxy: function (fn, context) {
-			return function () {
-				return fn.apply(context, arguments);
-			};
-		},
+		proxy: can.proxy,
 		attr: attr
 	});
 	// Wrap binding functions.

--- a/util/mootools/mootools.js
+++ b/util/mootools/mootools.js
@@ -103,12 +103,6 @@ steal('can/util/can.js', 'can/util/attr', 'mootools', 'can/event', 'can/util/fra
 			return Object.keys(object)
 				.length === 0;
 		};
-		// Map function helpers.
-		can.proxy = function () {
-			var args = can.makeArray(arguments),
-				func = args.shift();
-			return func.bind.apply(func, args);
-		};
 		can.isFunction = function (f) {
 			return typeOf(f) === 'function';
 		};

--- a/util/zepto/zepto.js
+++ b/util/zepto/zepto.js
@@ -180,12 +180,6 @@ steal('can/util/can.js', 'can/util/attr', 'can/event', 'zepto', 'can/util/object
 			return ret;
 		};
 
-		can.proxy = function (f, ctx) {
-			return function () {
-				return f.apply(ctx, arguments);
-			};
-		};
-
 		// Make ajax.
 		var XHR = $.ajaxSettings.xhr;
 		$.ajaxSettings.xhr = function () {


### PR DESCRIPTION
This pull request will use `Function.prototype.bind` for all `can.proxy` requests for libraries where there is no alternative implementation.

Closes #1632