### PR TITLE
Makes scope.computeData listen to every observable in scope when value is not defined.

### DIFF
--- a/compute/get_value_and_bind.js
+++ b/compute/get_value_and_bind.js
@@ -95,7 +95,7 @@ steal("can/util", function(){
 	can.__clearObserved = can.__clearReading = function () {
 		if (observedStack.length) {
 			var ret = observedStack[observedStack.length-1];
-			observedStack[observedStack.length-1] = {observed: {}};
+			observedStack[observedStack.length-1] = {names: "", observed: {}};
 			return ret;
 		}
 	};
@@ -108,7 +108,9 @@ steal("can/util", function(){
 
 	can.__addObserved = can.__addReading = function(o){
 		if (observedStack.length) {
-			can.simpleExtend(observedStack[observedStack.length-1], o);
+			var last = observedStack[observedStack.length-1];
+			can.simpleExtend(last.observed, o.observed);
+			last.names += o.names;
 		}
 	};
 	

--- a/test/pluginified/2.0.5.test.js
+++ b/test/pluginified/2.0.5.test.js
@@ -13618,30 +13618,7 @@ var __m78 = (function () {
 	 ok(fooInfo.parent ===  top, "we pick the current if we have no leads");
 
 	 })*/
-	test('use highest default observe in stack unless you\'ve found your way in something that does exist', function () {
-		var bottom = new can.Map({
-			name: {
-				first: 'Justin'
-			}
-		});
-		var middle = new can.Map({
-			name: {
-				first: 'Brian'
-			}
-		});
-		var top = new can.Map({
-			title: 'top'
-		});
-		var cur = new can.view.Scope(bottom)
-			.add(middle)
-			.add(top);
-		var lastNameInfo = cur.read('name.last', {});
-		ok(lastNameInfo.rootObserve === middle, 'pick the default observe with the highest depth');
-		deepEqual(lastNameInfo.reads, [
-			'name',
-			'last'
-		], 'pick the default observe with the highest depth');
-	});
+
 	/*	test("use observe like objects, e.g. can.route, within scope properly", function() {
 	 var expected = "video"
 	 var cur = new can.view.Scope({}).add(can.route);

--- a/view/callbacks/callbacks.js
+++ b/view/callbacks/callbacks.js
@@ -73,9 +73,9 @@ steal("can/util", "can/view",function(can){
 				res;
 				
 			if(tagCallback) {
-				var reads = can.__clearReading();
+				var reads = can.__clearObserved();
 				res = tagCallback(el, tagData);
-				can.__setReading(reads);
+				can.__setObserved(reads);
 			} else {
 				res = scope;
 			}

--- a/view/scope/compute_data.js
+++ b/view/scope/compute_data.js
@@ -38,12 +38,14 @@ steal("can/util","can/compute","can/compute/get_value_and_bind.js",function(can,
 	};
 	var scopeReader = function(scope, key, options, computeData, newVal){
 		if (arguments.length > 4) {
-			if(computeData.root.isComputed) {
-				computeData.root(newVal);
+			var root = computeData.root || computeData.setRoot;
+			
+			if(root.isComputed) {
+				root(newVal);
 			} else if(computeData.reads.length) {
 				var last = computeData.reads.length - 1;
-				var obj = computeData.reads.length ? can.compute.read(computeData.root, computeData.reads.slice(0, last)).value
-					: computeData.root;
+				var obj = computeData.reads.length ? can.compute.read(root, computeData.reads.slice(0, last)).value
+					: root;
 				can.compute.set(obj, computeData.reads[last], newVal, options);
 			}
 			// **Compute getter**
@@ -64,6 +66,7 @@ steal("can/util","can/compute","can/compute/get_value_and_bind.js",function(can,
 			computeData.initialValue = data.value;
 			computeData.reads = data.reads;
 			computeData.root = data.rootObserve;
+			computeData.setRoot = data.setRoot;
 			return data.value;
 		}
 	};

--- a/view/scope/scope_test.js
+++ b/view/scope/scope_test.js
@@ -1,26 +1,21 @@
 steal("can/view/scope", "can/route", "can/test", "steal-qunit", function () {
 	QUnit.module('can/view/scope');
-	/*	test("basics",function(){
+	
+	test("basics",function(){
 
-	 var items = { people: [{name: "Justin"},[{name: "Brian"}]], count: 1000 }; 
+		var items = new can.Map({ people: [{name: "Justin"},[{name: "Brian"}]], count: 1000 });
+		
+		var itemsScope = new can.view.Scope(items),
+		arrayScope = new can.view.Scope(itemsScope.attr('people'), itemsScope),
+		firstItem = new can.view.Scope( arrayScope.attr('0'), arrayScope );
+		
+		var nameInfo = firstItem.read('name');
+		deepEqual(nameInfo.reads, ["name"]);
+		equal(nameInfo.scope, firstItem);
+		equal(nameInfo.value,"Justin");
+		equal(nameInfo.rootObserve, items.people[0]);
 
-	 var itemsScope = new can.view.Scope(items),
-	 arrayScope = new can.view.Scope(itemsScope.attr('people'), itemsScope),
-	 firstItem = new can.view.Scope( arrayScope.attr('0'), arrayScope );
-
-	 var nameInfo = firstItem.get('name');
-	 equal(nameInfo.name, "name");
-	 equal(nameInfo.scope, firstItem);
-	 equal(nameInfo.value,"Justin");
-	 equal(nameInfo.parent, items.people[0]);
-
-	 var countInfo = firstItem.get('count');
-	 equal( countInfo.name, "count" );
-	 equal( countInfo.scope, itemsScope );
-	 equal(countInfo.value,1000);
-	 equal(countInfo.parent, items);
-
-	 });*/
+	});
 	/*
 	 * REMOVE
 	 test("adding items",function(){
@@ -111,54 +106,7 @@ steal("can/view/scope", "can/route", "can/test", "steal-qunit", function () {
 		equal(cur.attr('..'), row, 'got row');
 		equal(cur.attr('../first'), 'Justin', 'got row');
 	});
-	/*	test("use highest default observe in stack", function(){
-	 var bottom = new can.Map({
-	 name: "bottom"
-	 });
-	 var top = new can.Map({
-	 name: "top"
-	 });
 
-	 var base = new can.view.Scope( bottom ),
-	 cur = base.add(top);
-
-	 var fooInfo = cur.get("foo");
-	 ok(fooInfo.parent ===  top, "we pick the current if we have no leads");
-
-	 })*/
-	test('use highest default observe in stack unless you\'ve found your way in something that does exist', function () {
-		var bottom = new can.Map({
-			name: {
-				first: 'Justin'
-			}
-		});
-		var middle = new can.Map({
-			name: {
-				first: 'Brian'
-			}
-		});
-		var top = new can.Map({
-			title: 'top'
-		});
-		var cur = new can.view.Scope(bottom)
-			.add(middle)
-			.add(top);
-		var lastNameInfo = cur.read('name.last', {});
-		ok(lastNameInfo.rootObserve === middle, 'pick the default observe with the highest depth');
-		deepEqual(lastNameInfo.reads, [
-			'name',
-			'last'
-		], 'pick the default observe with the highest depth');
-	});
-	/*	test("use observe like objects, e.g. can.route, within scope properly", function() {
-	 var expected = "video"
-	 var cur = new can.view.Scope({}).add(can.route);
-	 can.route.attr('type', expected);
-	 var type = cur.get('type'); 
-
-	 equal(type.value, expected);
-	 equal(type.parent, can.route);
-	 })*/
 	test('nested properties with compute', function () {
 		var me = new can.Map({
 			name: {
@@ -424,6 +372,26 @@ steal("can/view/scope", "can/route", "can/test", "steal-qunit", function () {
 		computeData.compute(5);
 		equal(compute(), 5, "updated compute value");
 		equal( computeData.compute(), 5, "the compute has the right value");
+	});
+	
+	test("computesData can find update when initially undefined parent scope becomes defined (#579)", function(){
+		expect(2);
+		
+		var map = new can.Map();
+		var scope = new can.view.Scope(map);
+		var top = scope.add(new can.Map());
+		
+		var computeData = top.computeData("value",{});
+		
+		equal( computeData.compute(), undefined, "initially undefined");
+		
+		computeData.compute.bind("change", function(ev, newVal){
+			equal(newVal, "first");
+		});
+		
+		map.attr("value","first");
+		
+		
 	});
 
 });

--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -498,9 +498,9 @@ steal("can/util",
 					// we hide any observables read in the function by saving any observables that
 					// have been read and then setting them back which overwrites any `can.__observe` calls
 					// performed in value.
-					var old = can.__clearReading();
+					var old = can.__clearObserved();
 					value(this);
-					can.__setReading(old);
+					can.__setObserved(old);
 					
 				}
 				// If the compute has observable dependencies, setup live binding.


### PR DESCRIPTION
For #579, this binds on everything until a specific value becomes defined.

The change was pretty simple.  All I had to do was keep track of all "read" observables and re-apply them.

If this does slow down an app.  There are three fixes:

- leakScope: false
- default undefined values to null
- use ../ or ./

