### PR TITLE
Reference values 

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -255,6 +255,11 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 						hookupOptions.scope.add(this.scope),
 					options = {
 						helpers: {}
+					},
+					addHelper = function(name, fn) {
+						options.helpers[name] = function() {
+							return fn.apply(componentScope, arguments);
+						};
 					};
 
 				// ## Helpers
@@ -262,13 +267,23 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 				// Setup helpers to callback with `this` as the component
 				can.each(this.helpers || {}, function (val, prop) {
 					if (can.isFunction(val)) {
-						options.helpers[prop] = function () {
-							return val.apply(componentScope, arguments);
-						};
+						addHelper(prop, val);
 					}
 				});
-				
-				
+
+				// Setup simple helpers
+				can.each(this.simpleHelpers || {}, function(val, prop) {
+					//!steal-remove-start
+					if(options.helpers[prop]) {
+						can.dev.warn('Component ' + component.tag +
+						' already has a helper called ' + prop);
+					}
+					//!steal-remove-end
+
+					// Convert the helper
+					addHelper(prop, can.view.simpleHelper(val));
+				});
+
 				// Teardown reverse bindings when the element is removed
 				teardownFunctions.push(function(){
 					can.each(handlers, function (handler, prop) {

--- a/component/component.js
+++ b/component/component.js
@@ -12,7 +12,7 @@
 steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "can/observe", "can/view/mustache", "can/view/bindings", function (can, viewCallbacks, elements) {
 	// ## Helpers
 	// Attribute names to ignore for setting viewModel values.
-	var ignoreAttributesRegExp = /^(dataViewId|class|id)$/i,
+	var ignoreAttributesRegExp = /^(dataViewId|class|id|\[[\w\.]+\])$/i,
 		paramReplacer = /\{([^\}]+)\}/g;
 
 	/**
@@ -94,7 +94,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 			 */
 			// ### setup
 			// When a new component instance is created, setup bindings, render the template, etc.
-			setup: function (el, hookupOptions) {
+			setup: function (el, componentTagData) {
 				// Setup values passed to component
 				var initialScopeData = {},
 					component = this,
@@ -149,14 +149,14 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 						value = value.substr(1, value.length - 2 );
 					} else {
 						// Legacy template types will crossbind "foo=bar"
-						if(hookupOptions.templateType !== "legacy") {
+						if(componentTagData.templateType !== "legacy") {
 							initialScopeData[name] = value;
 							return;
 						}
 					}
 					// Cross-bind the value in the scope to this
 					// component's viewModel
-					var computeData = hookupOptions.scope.computeData(value, {
+					var computeData = componentTagData.scope.computeData(value, {
 						args: []
 					}),
 						compute = computeData.compute;
@@ -199,7 +199,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 					componentScope = scope;
 				} else if (can.isFunction(scope)) {
 					// If `this.viewModel` is a function, call the function and
-					var scopeResult = scope.call(this, initialScopeData, hookupOptions.scope, el);
+					var scopeResult = scope.call(this, initialScopeData, componentTagData.scope, el);
 
 					if (scopeResult instanceof can.Map) {
 						// If the function returns a can.Map, use that as the viewModel
@@ -231,7 +231,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 					componentScope.bind(prop, handlers[prop]);
 				});
 				// Setup the attributes bindings
-				if (!can.isEmptyObject(this.constructor.attributeScopeMappings) || hookupOptions.templateType !== "legacy") {
+				if (!can.isEmptyObject(this.constructor.attributeScopeMappings) || componentTagData.templateType !== "legacy") {
 					// Bind on the `attributes` event and update the viewModel.
 					can.bind.call(el, "attributes", function (ev) {
 						// Convert attribute name from the `attribute-name` to the `attributeName` format.
@@ -250,9 +250,9 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 				can.data(can.$(el), "viewModel", this.scope);
 
 				// Create a real Scope object out of the viewModel property
-				var renderedScope = lexicalContent ?
-						this.scope :
-						hookupOptions.scope.add(this.scope),
+				var renderedScope = (lexicalContent ?
+						can.view.Scope.refsScope() :
+						componentTagData.scope.add( new can.view.Scope.Refs() ) ).add(this.scope),
 					options = {
 						helpers: {}
 					},
@@ -330,14 +330,16 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 					}
 
 					// We need be alerted to when a <content> element is rendered so we can put the original contents of the widget in its place
-					options.tags.content = function contentHookup(el, rendererOptions) {
+					options.tags.content = function contentHookup(el, contentTagData) {
 						// First check if there was content within the custom tag
-						// otherwise, render what was within <content>, the default code
-						var subtemplate = hookupOptions.subtemplate || rendererOptions.subtemplate;
+						// otherwise, render what was within <content>, the default code.
+						// `componentTagData.subtemplate` is the content inside this component
+						var subtemplate = componentTagData.subtemplate || contentTagData.subtemplate,
+							renderingLightContent = subtemplate === componentTagData.subtemplate;
 
 						if (subtemplate) {
 
-							// `rendererOptions.options` is a viewModel of helpers where `<content>` was found, so
+							// `contentTagData.options` is a viewModel of helpers where `<content>` was found, so
 							// the right helpers should already be available.
 							// However, `_tags.content` is going to point to this current content callback.  We need to 
 							// remove that so it will walk up the chain
@@ -349,15 +351,33 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 							// bindings inside the "light dom" content of
 							// the component will have access to the
 							// internal viewModel. This can be overridden to be
-							// lexical with the lexicalContent
-							// option,
-							var opts = !lexicalContent ||
-									subtemplate !== hookupOptions.subtemplate ?
-									rendererOptions :
-									hookupOptions;
+							// lexical with the leakScope option.
+							var opts;
+							if( renderingLightContent ) {
+								if(lexicalContent) {
+									// render with the same scope the component was found within.
+									opts = componentTagData;
+								} else {
+									// render with the component's viewModel mixed in, however
+									// we still want the outer refs to be used, NOT the component's refs
+									// <component> {{some value }} </component>
+									// To fix this, we
+									// walk down the scope to the component's ref, clone scopes from that point up
+									// use that as the new scope.
+									opts = {
+										scope: contentTagData.scope.cloneFromRef(),
+										options: contentTagData.options
+									};
+								}
+								
+							} else {
+								// we are rendering default content so this content should 
+								// use the same scope as the <content> tag was found within.
+								opts = contentTagData;
+							}
 							
-							if(rendererOptions.parentNodeList) {
-								var frag = subtemplate( opts.scope, opts.options, rendererOptions.parentNodeList );
+							if(contentTagData.parentNodeList) {
+								var frag = subtemplate( opts.scope, opts.options, contentTagData.parentNodeList );
 								elements.replace([el], frag);
 							} else {
 								can.view.live.replace([el], subtemplate( opts.scope, opts.options ));
@@ -368,15 +388,15 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 						}
 					};
 					// Render the component's template
-					frag = this.constructor.renderer(renderedScope, hookupOptions.options.add(options), nodeList);
+					frag = this.constructor.renderer(renderedScope, componentTagData.options.add(options), nodeList);
 				} else {
 					// Otherwise render the contents between the 
-					if(hookupOptions.templateType === "legacy") {
-						frag = can.view.frag(hookupOptions.subtemplate ? hookupOptions.subtemplate(renderedScope, hookupOptions.options.add(options)) : "");
+					if(componentTagData.templateType === "legacy") {
+						frag = can.view.frag(componentTagData.subtemplate ? componentTagData.subtemplate(renderedScope, componentTagData.options.add(options)) : "");
 					} else {
 						// we need to be the parent ... or we need to 
-						frag = hookupOptions.subtemplate ?
-							hookupOptions.subtemplate(renderedScope, hookupOptions.options.add(options), nodeList) :
+						frag = componentTagData.subtemplate ?
+							componentTagData.subtemplate(renderedScope, componentTagData.options.add(options), nodeList) :
 							document.createDocumentFragment();
 					}
 					

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1656,4 +1656,23 @@ steal("can", "can/map/define", "can/component", "can/view/stache" ,"can/route", 
 			}, 20);
 		});
 	}
+
+	test('component simpleHelpers', function() {
+		can.Component.extend({
+			tag: 'simple-helper',
+			template: can.stache('Result: {{add first second}}'),
+			scope: {
+				first: 4,
+				second: 3
+			},
+			simpleHelpers: {
+				add: function(a, b) {
+					return a + b;
+				}
+			}
+		});
+
+		var frag = can.stache('<simple-helper></simple-helper>')();
+		equal(frag.childNodes[0].innerHTML, 'Result: 7');
+	});
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "can",
 	"title": "CanJS",
 	"description": "MIT-licensed, client-side, JavaScript framework that makes building rich web applications easy.",
-	"version": "2.2.6",
+	"version": "2.3.0-pre.0",
 	"author": {
 		"name": "Bitovi",
 		"email": "contact@bitovi.com",

--- a/view/bindings/doc/can-event.md
+++ b/view/bindings/doc/can-event.md
@@ -1,5 +1,9 @@
-@function can.view.bindings.can-EVENT can-EVENT
+@function can.view.bindings.can-EVENT can-EVENT/(EVENT)
 @parent can.view.bindings
+
+@signature `(EVENT)='{methodKey [argKey..] [hashName=hashKey...]}'`
+
+Specify a callback function to be called on a particular event. This is a shorthand for `can-EVENT` attributes.
 
 @signature `can-EVENT='{methodKey [argKey..] [hashName=hashKey...]}'`
 
@@ -62,7 +66,7 @@ can.view.bindings supports creating special event types
 bound by adding attributes like `can-SPECIAL='KEY'`. This is 
 similar to [$.special](http://benalman.com/news/2010/03/jquery-special-events/).
 
-### can-enter
+### can-enter / (enter)
 
 can-enter is a special event that calls its handler whenever the enter 
 key is pressed while focused on the current element. For example: 

--- a/view/bindings/doc/import-scope.md
+++ b/view/bindings/doc/import-scope.md
@@ -1,0 +1,21 @@
+@function can.view.bindings.import-scope [prop]="{childProp}"
+@parent can.view.bindings
+
+@signature `[prop]="{childProp}"`
+
+Imports a property from a child components viewmodel into this scope.
+
+@param {String} prop The name of the property to set in the current scope.
+
+@param {String} childProp The name of the property to import from the child components viewmodel. Use `{this}` or `{.}` to import the entire viewmodel.
+
+@body
+
+## Use
+
+`[prop]="{childProp}"` can be used to import single values or the complete view model from a child component into the current scope without having to set up a shared property in the parent component. For example, a `car-selector` parent component that contains a `year-selector` and a `car-list` component where we want to share the `selectedYear` property from `year-selector` as the `year` property can be done like this:
+
+	<car-selector>
+		<year-selector [year]="{selectedYear}" />
+		<car-list selection="{year}" />
+	</car-selector>

--- a/view/doc/elements_and_attributes.md
+++ b/view/doc/elements_and_attributes.md
@@ -14,15 +14,28 @@ The following is supported by CanJS's [can.mustache] and [can.stache] templates 
 
  - [can.view.bindings.can-EVENT] - Specify a callback function to be called on a particular event. 
  
+	`<div can-click="{doSomething item}">...</div>`
+
+  OR
+
+	`<div (click)="{doSomething item}">...</div>`
+
+ - [can.view.bindings.import-scope] - Import values or the complete view model from a child component into the current scope with `[prop]="{childProp}"`
+
    ```
-   <div can-click="{doSomething item}">...</div>
+	<car-selector>
+		<year-selector [year]="{selectedYear}" />
+		<car-list selection="{year}" />
+	</car-selector>
    ```
- 
+
  - [can.view.bindings.can-value] - Sets up two way bindings in a template.
  
    ```
    <input can-value="{name}"/>
    ```
+
+ - [can.view.href] - Sets an element's href attribute so that it's url will set the specified attribute values on [can.route].
 
 ## Plugins
 

--- a/view/href/href.js
+++ b/view/href/href.js
@@ -1,0 +1,49 @@
+steal("can/util",
+	"can/view/stache/mustache_core.js",
+	"can/view/callbacks",
+	"can/view/scope", function (can, mustacheCore) {
+
+
+	var removeCurly = function(value){
+		if(value[0] === "{" && value[value.length-1] === "}") {
+			return value.substr(1, value.length - 2);
+		}
+		return value;
+	};
+
+	// registers a callback can-href
+	can.view.attr("can-href", function(el, attrData){
+
+		// foo='bar' zed=5 abc=myValue
+		// Note: 'tmp ' is added because expressionData "Breaks up the name and arguments of a mustache expression.", but we don't use name:
+		var attrInfo = mustacheCore.expressionData('tmp ' + removeCurly(el.getAttribute("can-href")));
+		// -> {hash: {foo: 'bar', zed: 5, abc: {get: 'myValue'}}}
+
+		var routeHref = can.compute(function(){
+			var hash = {};
+			can.each(attrInfo.hash, function(val, key) {
+				if (val && val.hasOwnProperty("get")) {
+					hash[key] = attrData.scope.read(val.get, {}).value;
+				} else {
+					hash[key] = val;
+				}
+			});
+			return can.route.url(hash);
+		});
+
+
+		el.setAttribute("href", routeHref());
+
+		var handler = function(ev, newVal){
+			el.setAttribute("href", newVal);
+		};
+
+		routeHref.bind("change", handler );
+
+		can.bind.call(el,"removed", function(){
+			routeHref.unbind("change", handler );
+		});
+	});
+
+
+});

--- a/view/href/href.md
+++ b/view/href/href.md
@@ -1,0 +1,55 @@
+@page can.view.href
+@parent can.view.bindings
+
+Sets an element's href attribute so that it's url will set the specified attribute values on [can.route].
+
+@siganture `can-href='{[attrName=attrValue...]}'`
+
+@param {String} attrName
+@param {can.stache.key} attrValue
+
+@body
+
+## Use
+
+With no pretty routing rules, the following:
+
+```
+<li><a can-href='{page="recipe" id=5}'>{{recipe.name}}</a></li>
+```
+
+produces:
+
+```
+<li><a href='#!&page=5&id=5'>{{recipe.name}}</a></li>
+```
+
+If pretty route is defined like:
+
+```
+can.route(":page/:id")
+```
+
+The previous use of `can-href` will instead produce:
+
+```
+<li><a href='#!page/5'>{{recipe.name}}</a></li>
+```
+
+You can use values from stache's scope like:
+
+```
+<li><a can-href='{page="recipe" id=recipeId}'>{{recipe.name}}</a></li>
+```
+
+If `recipeId` was 6:
+
+```
+<li><a href='#!page/6'>{{recipe.name}}</a></li>
+```
+
+If `recipeId` is observable and changes to 7:
+
+```
+<li><a href='#!page/7'>{{recipe.name}}</a></li>
+```

--- a/view/href/href_test.js
+++ b/view/href/href_test.js
@@ -1,0 +1,52 @@
+steal("can/test", "steal-qunit", "can/route", function () {
+
+	var makeIframe = function(src){
+		var iframe = document.createElement('iframe');
+		window.removeMyself = function(){
+			delete window.removeMyself;
+			delete window.isReady;
+			delete window.hasError;
+			document.body.removeChild(iframe);
+			start();
+		};
+		window.hasError = function(error) {
+			ok(false, error.message);
+			window.removeMyself();
+		};
+		window.isReady = function(el, viewModel, setPrettyUrl) {
+
+			equal(el.find('a').attr('href'), "#!&page=recipe&id=5", "should set unpretty href attribute");
+
+			viewModel.recipe.attr('id', 7);
+			equal(el.find('a').attr('href'), "#!&page=recipe&id=7", "should update href");
+
+			setPrettyUrl();
+			viewModel.recipe.attr('id', 8);
+			equal(el.find('a').attr('href'), "#!recipe/8", "should set pretty href");
+
+			viewModel.recipe.attr('id', 9);
+			equal(el.find('a').attr('href'), "#!recipe/9", "should update pretty href");
+
+			window.removeMyself();
+		};
+		document.body.appendChild(iframe);
+		iframe.src = src;
+	};
+
+	QUnit.module("can/view/href");
+	if(window.steal) {
+		asyncTest("the basics are able to work for steal", function(){
+			makeIframe(  can.test.path("view/href/tests/steal-basics.html?"+Math.random()) );
+		});
+	}
+	//else if(window.requirejs) {
+	//	asyncTest("the basics are able to work for requirejs", function(){
+	//		makeIframe(can.test.path("../../view/href/tests/requirejs-basics.html?"+Math.random()));
+	//	});
+	//} else {
+	//	asyncTest("the basics are able to work standalone", function(){
+	//		makeIframe(can.test.path("view/href/tests/standalone-basics.html?"+Math.random()));
+	//	});
+	//}
+
+});

--- a/view/href/test.html
+++ b/view/href/test.html
@@ -1,0 +1,3 @@
+<title>can/view/href</title>
+<script src="../../node_modules/steal/steal.js" main="can/view/href/href_test"></script>
+<div id="qunit-fixture"></div>

--- a/view/href/tests/steal-basics.html
+++ b/view/href/tests/steal-basics.html
@@ -1,0 +1,27 @@
+<script>
+	window.isReady = window.parent.isReady || function(el) {
+		console.log(el.length);
+		console.log(el.html());
+	};
+	window.hasError = window.parent.hasError || function(error) {
+		console.log("error in autoload", error)
+	};
+	window.removeMyself = window.parent.removeMyself;
+</script>
+<script type="text/stache" id="basics">
+	<a can-href="{page='recipe' id=recipe.id}">{{recipe.name}}</a>
+</script>
+<script src='../../../node_modules/steal/steal.js' main='can/view/href/'></script>
+
+
+<script>
+	steal('can', 'can/view/href', 'can/view/href/tests/steal-basics.js', function(can){
+		console.log();
+		$("body").html(can.view.mustache('<href-component>Test component</href-component>'));
+		isReady($("body href-component"), can.viewModel('href-component'), function(){
+			can.route(":page/:id");
+		});
+	});
+</script>
+
+

--- a/view/href/tests/steal-basics.js
+++ b/view/href/tests/steal-basics.js
@@ -1,0 +1,17 @@
+steal("can/component", "can/util",function(Component, can){
+	return Component.extend({
+		tag: "href-component",
+		template: $('#basics').html(),
+		viewModel: {
+			recipe: {
+				id: 5,
+				name: 'Cool recipe'
+			}
+		},
+		events: {
+			"inserted": function(){
+				console.log('href-component INSERTED');
+			}
+		}
+	});
+});

--- a/view/mustache/doc/simplehelper.md
+++ b/view/mustache/doc/simplehelper.md
@@ -1,0 +1,81 @@
+@typedef {function(this:can.mustache.context,...*,can.mustache.sectionOptions){}} can.mustache.simpleHelper(arg,options)
+@parent can.mustache.types
+
+@description A helper function passed to [can.mustache.registerSimpleHelper].
+
+@param {...*} [arg] Arguments passed from the tag. After the helper
+name, any space seperated [can.mustache.key keys], numbers or
+strings are passed as arguments.
+
+The following template:
+
+    <p>{{madLib "Lebron James" verb 4}}</p>
+
+Rendered with
+
+    {verb: "swept"}
+
+Will call a `madLib` helper with the following arguements.
+
+    can.mustache.registerSimpleHelper('madLib',
+      function(subject, verb, number){
+        // subject -> "Lebron James"
+        // verb -> "swept"
+        // number -> 4
+    });
+
+Unlike [can.mustache.helper] simple helpers will always pass the actual
+value (instead of a compute).
+
+@param {can.mustache.helperOptions} options An options object
+that gets populated with optional:
+
+- `fn` and `inverse` section rendering functions
+- a `hash` object of the maps passed to the helper
+
+@this {can.mustache.context} The context the helper was
+called within.
+
+@return {String|function(HTMLElement)} The content to be inserted into
+the template.
+
+@body
+
+can.mustache.simpleHelper
+
+## Returning an element callback function
+
+If a helper returns a function, that function is called back after
+the template has been rendered into DOM elements. This can
+be used to create mustache tags that have rich behavior.
+
+If the helper is called __within a tag__ like:
+
+    <ul {{sortable}}/>
+
+The returned function is called with the `<ul>` element:
+
+    can.mustache.registerSimpleHelper("sortable",function(){
+      return function(el){
+        $(el).slider();
+      }
+    });
+
+If the helper is called __between tags__ like:
+
+    <ul>{{items}}</ul>
+
+The returned function is called with a temporary element. The
+following helper would be called with a temporary `<li>` element:
+
+    can.mustache.registerSimpleHelper("items",function(){
+      return function(li){
+
+      }
+    });
+
+The temporary element depends on the parent element. The default temporary element
+is a `<span>` element.
+
+
+

--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1645,6 +1645,27 @@ steal('can/util',
 		};
 
 		/**
+		 * @function can.mustache.registerSimpleHelper
+		 * @parent can.mustache.methods
+		 * @description Register a simple helper.
+		 * @function can.mustache.registerSimpleHelper registerSimpleHelper
+		 * @signature `Mustache.registerSimpleHelper(name, helper)`
+		 * @param {String} name The name of the helper.
+		 * @param {can.mustache.simplehelper} helper The simple helper function.
+		 *
+		 * @body
+		 * Registers a helper with the Mustache system that passes the values
+		 * instead of computes as arguments. This is useful if your helper does not
+		 * modify the argument computes and you only need the actual values.
+		 * Pass the name of the helper followed by the
+		 * function to which Mustache should invoke.
+		 * These are run at runtime.
+		 */
+		Mustache.registerSimpleHelper = function(name, fn) {
+			Mustache.registerHelper(name, can.view.simpleHelper(fn));
+		};
+
+		/**
 		 * @hide
 		 * @function can.MustacheConstructor.getHelper getHelper
 		 * @description Retrieve a helper.

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -4039,5 +4039,20 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 
 		// Helpers evaluated 3rd time...
 		state.attr('parent.child', 'bar');
+	});	
+
+	test('registerSimpleHelper', 3, function() {
+		can.Mustache.registerSimpleHelper('simple', function(first, second) {
+			equal(first, 2);
+			equal(second, 4);
+			return first + second;
+		});
+
+		var template = can.view.mustache('<div>Result: {{simple first second}}</div>');
+		var frag = template(new can.Map({
+			first: 2,
+			second: 4
+		}));
+		equal(frag.childNodes[0].innerHTML, 'Result: 6');
 	});
 });

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -4039,7 +4039,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 
 		// Helpers evaluated 3rd time...
 		state.attr('parent.child', 'bar');
-	});	
+	});
 
 	test('registerSimpleHelper', 3, function() {
 		can.Mustache.registerSimpleHelper('simple', function(first, second) {

--- a/view/mutation/mutation.js
+++ b/view/mutation/mutation.js
@@ -1,0 +1,68 @@
+/**
+ * Mutates the DOM or a virtualDOM
+ */
+steal("can/util", 'can/view/parser',"can/view/elements.js", function(can, parser, elements){
+	
+	var getAttributeParts = function (newVal) {
+		var attrs = {},
+			attr;
+		parser.parseAttrs(newVal,{
+			attrStart: function(name){
+				attrs[name] = "";
+				attr = name;
+			},
+			attrValue: function(value){
+				attrs[attr] += value;
+			},
+			attrEnd: function(){}
+		});
+		return attrs;
+	};
+	
+	
+	var mutation = {
+		setAttribute: function(node, attr, value){
+			if(node.nodeType) {
+				can.attr.set(node, attr, value);
+			} else {
+				var child = node.parent.children[node.index];
+				if(!child.attrs) {
+					child.attrs = {};
+				}
+				child.attrs[attr] = value;
+			}
+		},
+		setAttributes: function(node, attributes){
+			var attrs = getAttributeParts(attributes);
+			for(var name in attrs) {
+				mutation.setAttribute(node, name, attrs[name]);
+			}
+			if(!node.nodeType) {
+				delete node.parent.children[node.index].attributes;
+			}
+		},
+		replace: function(node, value){
+			if(this.nodeName) {
+				elements.replace([node], can.frag(value));
+			} else {
+				var children = node.parent.children;
+				children.splice.apply(children, [node.index, 1].concat( value ) );
+			}
+		},
+		text: function(node, value){
+			if(node.nodeName) {
+				node.nodeValue = value;
+			} else {
+				// should we be escaping this text?  all text nodes will be escaped
+				// but someone could put in an object
+				var children = node.parent.children;
+				children.splice.apply(children, [node.index, 1].concat( value ) );
+			}
+		},
+		remove: function(node) {
+			
+		}
+	};
+	return mutation;
+});
+

--- a/view/parser/parser.js
+++ b/view/parser/parser.js
@@ -18,8 +18,7 @@ steal("can/view", function(can){
 		return intermediate;
 	}
 	
-	var alpha = 
-		alphaNumericHU = "-:A-Za-z0-9_",
+	var alphaNumericHU = "-:A-Za-z0-9_",
 		attributeNames = "[^=>\\s\\{\\}\\/]+",
 		spaceEQspace = "\\s*=\\s*",
 		dblQuote2dblQuote = "\"((?:\\\\.|[^\"])*)\"",

--- a/view/parser/parser.js
+++ b/view/parser/parser.js
@@ -18,8 +18,9 @@ steal("can/view", function(can){
 		return intermediate;
 	}
 	
-	var alphaNumericHU = "-:A-Za-z0-9_",
-		attributeNames = "[a-zA-Z_:]["+alphaNumericHU+":.]*",
+	var alpha = 
+		alphaNumericHU = "-:A-Za-z0-9_",
+		attributeNames = "[^=>\\s\\{\\}\\/]+",
 		spaceEQspace = "\\s*=\\s*",
 		dblQuote2dblQuote = "\"((?:\\\\.|[^\"])*)\"",
 		quote2quote = "'((?:\\\\.|[^'])*)'",
@@ -164,6 +165,7 @@ steal("can/view", function(can){
 		};
 
 		while (html) {
+
 			chars = true;
 
 			// Make sure we're not in a script or style element

--- a/view/parser/parser_test.js
+++ b/view/parser/parser_test.js
@@ -188,5 +188,37 @@ steal("can/view/parser", "steal-qunit", function(parser){
 		parser(intermediate, makeChecks(tests) );
 	});
 	
+	test('allow () and [] to enclose attributes', function() {
+		parser('<p [click]="test"></p>', makeChecks([
+			["start", ["p", false]],
+			["attrStart", ["[click]"]],
+			["attrValue", ["test"]],
+			["attrEnd", ["[click]"]],
+			["end",["p"]],
+			["close",["p"]],
+			["done",[]]
+		]));
+
+		parser('<p (click)="test"></p>', makeChecks([
+			["start", ["p", false]],
+			["attrStart", ["(click)"]],
+			["attrValue", ["test"]],
+			["attrEnd", ["(click)"]],
+			["end",["p"]],
+			["close",["p"]],
+			["done",[]]
+		]));
+	});
+	
+	test('allow #attribute', function() {
+		parser('<p #foo></p>', makeChecks([
+			["start", ["p", false]],
+			["attrStart", ["#foo"]],
+			["attrEnd", ["#foo"]],
+			["end",["p"]],
+			["close",["p"]],
+			["done",[]]
+		]));
+	});
 	
 });

--- a/view/stache/doc/helpers/registerSimpleHelper.md
+++ b/view/stache/doc/helpers/registerSimpleHelper.md
@@ -1,0 +1,15 @@
+@function can.stache.registerSimpleHelper registerSimpleHelper
+@description Register a helper.
+@parent can.stache.static
+
+@signature `can.stache.registerSimpleHelper(name, helper)`
+@param {String} name The name of the helper.
+@param {can.stache.simplehelper} helper The helper function.
+
+@body
+
+Registers a helper with the Mustache system that always returns
+the arguments value (instead of a compute).
+Pass the name of the helper followed by the
+function to which Mustache should invoke.
+These are run at runtime.

--- a/view/stache/doc/simplehelper.md
+++ b/view/stache/doc/simplehelper.md
@@ -1,0 +1,81 @@
+@typedef {function(this:can.stache.context,...*,can.stache.sectionOptions){}} can.stache.simpleHelper(arg,options)
+@parent can.stache.types
+
+@description A helper function passed to [can.stache.registerSimpleHelper].
+
+@param {...*} [arg] Arguments passed from the tag. After the helper
+name, any space seperated [can.stache.key keys], numbers or
+strings are passed as arguments.
+
+The following template:
+
+    <p>{{madLib "Lebron James" verb 4}}</p>
+
+Rendered with
+
+    {verb: "swept"}
+
+Will call a `madLib` helper with the following arguements.
+
+    can.stache.registerSimpleHelper('madLib',
+      function(subject, verb, number){
+        // subject -> "Lebron James"
+        // verb -> "swept"
+        // number -> 4
+    });
+
+Unlike [can.stache.helper] simple helpers will always pass the actual
+value (instead of a compute).
+
+@param {can.stache.helperOptions} options An options object
+that gets populated with optional:
+
+- `fn` and `inverse` section rendering functions
+- a `hash` object of the maps passed to the helper
+
+@this {can.stache.context} The context the helper was
+called within.
+
+@return {String|function(HTMLElement)} The content to be inserted into
+the template.
+
+@body
+
+can.stache.simpleHelper
+
+## Returning an element callback function
+
+If a helper returns a function, that function is called back after
+the template has been rendered into DOM elements. This can
+be used to create mustache tags that have rich behavior.
+
+If the helper is called __within a tag__ like:
+
+    <ul {{sortable}}/>
+
+The returned function is called with the `<ul>` element:
+
+    can.stache.registerSimpleHelper("sortable",function(){
+      return function(el){
+        $(el).slider();
+      }
+    });
+
+If the helper is called __between tags__ like:
+
+    <ul>{{items}}</ul>
+
+The returned function is called with a temporary element. The
+following helper would be called with a temporary `<li>` element:
+
+    can.stache.registerSimpleHelper("items",function(){
+      return function(li){
+
+      }
+    });
+
+The temporary element depends on the parent element. The default temporary element
+is a `<span>` element.
+
+
+

--- a/view/stache/html_section.js
+++ b/view/stache/html_section.js
@@ -63,7 +63,7 @@ steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( c
 			
 			return function(scope, options, nodeList){
 				if ( !(scope instanceof can.view.Scope) ) {
-					scope = new can.view.Scope(scope || {});
+					scope = can.view.Scope.refsScope().add(scope || {});
 				}
 				if ( !(options instanceof mustacheCore.Options) ) {
 					options = new mustacheCore.Options(options || {});

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -150,10 +150,15 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			};
 		}
 	};
-	
+
+	var registerHelper = function(name, callback){
+		helpers[name] = callback;
+	};
+
 	return {
-		registerHelper: function(name, callback){
-			helpers[name] = callback;
+		registerHelper: registerHelper,
+		registerSimpleHelper: function(name, callback) {
+			registerHelper(name, can.view.simpleHelper(callback));
 		},
 		getHelper: function(name, options){
 			var helper = options.attr("helpers." + name);

--- a/view/stache/stache.js
+++ b/view/stache/stache.js
@@ -115,7 +115,7 @@ steal(
 				if( !node.attributes ) {
 					node.attributes = [];
 				}
-				node.attributes.push(callback);
+				node.attributes.unshift(callback);
 			};
 		
 		parser(template,{

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -3946,7 +3946,6 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		equal(frag.firstChild.firstChild.nodeValue, "def", "correct value");
 	});
 	
-
 	test('template with a block section and nested if doesnt render correctly', function() {
 		var myMap = new can.Map({
 			bar: true
@@ -4019,4 +4018,19 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		// Helpers evaluated 3rd time...
 		state.attr('parent.child', 'bar');
 	});
+
+	test('registerSimpleHelper', 3, function() {
+		var template = can.stache('<div>Result: {{simple first second}}</div>');
+		can.stache.registerSimpleHelper('simple', function(first, second) {
+			equal(first, 2);
+			equal(second, 4);
+			return first + second;
+		});
+		var frag = template(new can.Map({
+			first: 2,
+			second: 4
+		}));
+		equal(frag.childNodes[0].innerHTML, 'Result: 6');
+	});
+	
 });

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -360,7 +360,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 	});
 
 	test("Handlebars advanced helpers (from docs)", function () {
-		can.stache.registerHelper('exercise', function (group, action, num, options) {
+		can.stache.registerSimpleHelper('exercise', function (group, action, num, options) {
 			if (group && group.length > 0 && action && num > 0) {
 				return options.fn({
 					group: group,
@@ -395,9 +395,9 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		var div = document.createElement("div");
 		div.appendChild(frag);
 
-		equal(div.innerHTML, t.expected);
+		equal(div.innerHTML, t.expected, "with data");
 		
-		equal(getText(t.template, {}), t.expected2);
+		equal(getText(t.template, {}), t.expected2, "without data");
 	});
 
 	test("Passing functions as data, then executing them", function () {

--- a/view/target/target.js
+++ b/view/target/target.js
@@ -35,7 +35,20 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 
 			return clone.innerHTML === "<xyz></xyz>";
 		})(),
-		namespacesWork = typeof document !== "undefined" && !!document.createElementNS;
+		namespacesWork = typeof document !== "undefined" && !!document.createElementNS,
+		// A dummy element we use for creating non-standard attribute names (e.g. containing () and [])
+		attributeDummy = typeof document !== "undefined" ? document.createElement('div') : null,
+		// Sets the attribute on an element. Uses a hack when setAttribute complains
+		setAttribute = function(el, attrName, value) {
+			try {
+				el.setAttribute(attrName, value);
+			} catch(e) {
+				// We got an error. Set innerHTML with the non-standard attribute and clone
+				// that attribute node
+				attributeDummy.innerHTML = '<div ' + attrName + '="' + value + '"></div>';
+				el.setAttributeNode(attributeDummy.childNodes[0].attributes[0].cloneNode());
+			}
+		};
 
 	/**
 	 * @function cloneNode
@@ -69,7 +82,7 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 				var attributes = can.makeArray(node.attributes);
 				can.each(attributes, function (node) {
 					if(node && node.specified) {
-						copy.setAttribute(node.nodeName, node.nodeValue);
+						setAttribute(copy, node.nodeName, node.nodeValue);
 					}
 				});
 			}
@@ -118,7 +131,7 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 								callback:  value
 							});
 						} else  {
-							el.setAttribute(attrName, value);
+							setAttribute(el, attrName, value);
 						}
 					}
 				}

--- a/view/view.js
+++ b/view/view.js
@@ -726,6 +726,22 @@ steal('can/util', function (can) {
 			// Return the objects for the response's `dataTypes`
 			// (in this case view).
 			return def.resolve(renderer);
+		},
+
+		// Returns a function that automatically converts all computes passed to it
+		simpleHelper: function(fn) {
+			return function() {
+				var realArgs = [];
+				can.each(arguments, function(val, i) {
+					if (i <= arguments.length) {
+						while (val && val.isComputed) {
+							val = val();
+						}
+						realArgs.push(val);
+					}
+				});
+				return fn.apply(this, realArgs);
+			};
 		}
 	});
 


### PR DESCRIPTION
For #1700, this adds reference values exporting like:

```
<my-component #foo>
```

This also cherry-picks the parent context exporting:

```
<my-component [parentProp]="childProp"/>
```

- [ ] -This should be adding `#[\w\.]+` to `var ignoreAttributesRegExp`, but it is not.  
- [ ] - This needs docs.

This uses a new `can.view.Scope` method, `cloneFromRef` to make a context for "light dom" that uses the lexical semantics for the "refs".  `cloneFromRef` essentially copies a Scope, but with the component's refs removed.

