### PR TITLE
Binding to element's properties

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -1,7 +1,7 @@
 // # can/view/bindings/bindings.js
-// 
-// This file defines the `can-value` attribute for two-way bindings and the `can-EVENT` attribute 
-// for in template event bindings. These are usable in any mustache template, but mainly and documented 
+//
+// This file defines the `can-value` attribute for two-way bindings and the `can-EVENT` attribute
+// for in template event bindings. These are usable in any mustache template, but mainly and documented
 // for use within can.Component.
 steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can/control", "can/view/scope", function (can, mustacheCore) {
 	/**
@@ -63,18 +63,18 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 
 	// ## can-value
 	// Implement the `can-value` special attribute
-	// 
+	//
 	// ### Usage
-	// 		
+	//
 	// 		<input can-value="name" />
-	// 
-	// When a view engine finds this attribute, it will call this callback. The value of the attribute 
+	//
+	// When a view engine finds this attribute, it will call this callback. The value of the attribute
 	// should be a string representing some value in the current scope to cross-bind to.
 	can.view.attr("can-value", function (el, data) {
 
 		var attr = can.trim(removeBrackets(el.getAttribute("can-value"))),
-			// Turn the attribute passed in into a compute.  If the user passed in can-value="name" and the current 
-			// scope of the template is some object called data, the compute representing this can-value will be the 
+			// Turn the attribute passed in into a compute.  If the user passed in can-value="name" and the current
+			// scope of the template is some object called data, the compute representing this can-value will be the
 			// data.attr('name') property.
 			value = data.scope.computeData(attr, {
 				args: []
@@ -83,14 +83,14 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			trueValue,
 			falseValue;
 
-		// Depending on the type of element, this attribute has different behavior. can.Controls are defined (further below 
-		// in this file) for each type of input. This block of code collects arguments and instantiates each can.Control. There 
+		// Depending on the type of element, this attribute has different behavior. can.Controls are defined (further below
+		// in this file) for each type of input. This block of code collects arguments and instantiates each can.Control. There
 		// is one for checkboxes/radios, another for multiselect inputs, and another for everything else.
 		if (el.nodeName.toLowerCase() === "input") {
 			if (el.type === "checkbox") {
-				// If the element is a checkbox and has an attribute called "can-true-value", 
-				// set up a compute that toggles the value of the checkbox to "true" based on another attribute. 
-				// 
+				// If the element is a checkbox and has an attribute called "can-true-value",
+				// set up a compute that toggles the value of the checkbox to "true" based on another attribute.
+				//
 				// 		<input type='checkbox' can-value='sex' can-true-value='male' can-false-value='female' />
 				if (can.attr.has(el, "can-true-value")) {
 					trueValue = el.getAttribute("can-true-value");
@@ -105,8 +105,8 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			}
 
 			if (el.type === "checkbox" || el.type === "radio") {
-				// For checkboxes and radio buttons, create a Checked can.Control around the input.  Pass in 
-				// the compute representing the can-value and can-true-value and can-false-value properties (if 
+				// For checkboxes and radio buttons, create a Checked can.Control around the input.  Pass in
+				// the compute representing the can-value and can-true-value and can-false-value properties (if
 				// they were used).
 				new Checked(el, {
 					value: value,
@@ -117,7 +117,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			}
 		}
 		if (el.nodeName.toLowerCase() === "select" && el.multiple) {
-			// For multiselect enabled select inputs, we instantiate a special control around that select element 
+			// For multiselect enabled select inputs, we instantiate a special control around that select element
 			// called Multiselect
 			new Multiselect(el, {
 				value: value
@@ -131,7 +131,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			});
 			return;
 		}
-		// The default case. Instantiate the Value control around the element. Pass it the compute representing 
+		// The default case. Instantiate the Value control around the element. Pass it the compute representing
 		// the observable attribute property that was set.
 		new Value(el, {
 			value: value
@@ -140,13 +140,13 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 
 	// ## Special Event Types (can-SPECIAL)
 
-	// A special object, similar to [$.event.special](http://benalman.com/news/2010/03/jquery-special-events/), 
-	// for adding hooks for special can-SPECIAL types (not native DOM events). Right now, only can-enter is 
+	// A special object, similar to [$.event.special](http://benalman.com/news/2010/03/jquery-special-events/),
+	// for adding hooks for special can-SPECIAL types (not native DOM events). Right now, only can-enter is
 	// supported, but this object might be exported so that it can be added to easily.
-	// 
-	// To implement a can-SPECIAL event type, add a property to the special object, whose value is a function 
-	// that returns the following: 
-	//		
+	//
+	// To implement a can-SPECIAL event type, add a property to the special object, whose value is a function
+	// that returns the following:
+	//
 	//		// the real event name to bind to
 	//		event: "event-name",
 	//		handler: function (ev) {
@@ -274,24 +274,24 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 	};
 
 	// ## can-EVENT
-	// The following section contains code for implementing the can-EVENT attribute. 
-	// This binds on a wildcard attribute name. Whenever a view is being processed 
-	// and can-xxx (anything starting with can-), this callback will be run.  Inside, its setting up an event handler 
+	// The following section contains code for implementing the can-EVENT attribute.
+	// This binds on a wildcard attribute name. Whenever a view is being processed
+	// and can-xxx (anything starting with can-), this callback will be run.  Inside, its setting up an event handler
 	// that calls a method identified by the value of this attribute.
 	can.view.attr(/can-[\w\.]+/, handleEvent);
 	// ## (EVENT)
 	can.view.attr(/\([\w\.]+\)/, handleEvent);
 
 	// ## Two way binding can.Controls
-	// Each type of input that is supported by view/bindings is wrapped with a special can.Control.  The control serves 
-	// two functions: 
+	// Each type of input that is supported by view/bindings is wrapped with a special can.Control.  The control serves
+	// two functions:
 	// 1. Bind on the property changing (the compute we're two-way binding to) and change the input value.
 	// 2. Bind on the input changing and change the property (compute) we're two-way binding to.
 	// There is one control per input type. There could easily be more for more advanced input types, like the HTML5 type="date" input type.
 
 
-	// ### Value 
-	// A can.Control that manages the two-way bindings on most inputs.  When can-value is found as an attribute 
+	// ### Value
+	// A can.Control that manages the two-way bindings on most inputs.  When can-value is found as an attribute
 	// on an input, the callback above instantiates this Value control on the input element.
 	var Value = can.Control.extend({
 		init: function () {
@@ -333,8 +333,8 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			}
 		}
 	}),
-	// ### Checked 
-	// A can.Control that manages the two-way bindings on a checkbox element.  When can-value is found as an attribute 
+	// ### Checked
+	// A can.Control that manages the two-way bindings on a checkbox element.  When can-value is found as an attribute
 	// on a checkbox, the callback above instantiates this Checked control on the checkbox element.
 		Checked = can.Control.extend({
 			init: function () {
@@ -342,7 +342,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 				this.isCheckbox = (this.element[0].type.toLowerCase() === "checkbox");
 				this.check();
 			},
-			// `value` is the compute representing the can-value for this element.  For example can-value="foo" and current 
+			// `value` is the compute representing the can-value for this element.  For example can-value="foo" and current
 			// scope is someObj, value is the compute representing someObj.attr('foo')
 			"{value} change": "check",
 			check: function () {
@@ -350,7 +350,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 				if (this.isCheckbox) {
 					var value = this.options.value(),
 						trueValue = this.options.trueValue || true;
-					// If `can-true-value` attribute was set, check if the value is equal to that string value, and set 
+					// If `can-true-value` attribute was set, check if the value is equal to that string value, and set
 					// the checked property based on their equality.
 					this.element[0].checked = (value == trueValue);
 				}
@@ -368,7 +368,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			"change": function () {
 
 				if (this.isCheckbox) {
-					// If the checkbox is checked and can-true-value was used, set value to the string value of can-true-value.  If 
+					// If the checkbox is checked and can-true-value was used, set value to the string value of can-true-value.  If
 					// can-false-value was used and checked is false, set value to the string value of can-false-value.
 					this.options.value(this.element[0].checked ? this.options.trueValue : this.options.falseValue);
 				}
@@ -382,7 +382,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			}
 		}),
 		// ### Multiselect
-		// A can.Control that handles select input with the "multiple" attribute (meaning more than one can be selected at once). 
+		// A can.Control that handles select input with the "multiple" attribute (meaning more than one can be selected at once).
 		Multiselect = Value.extend({
 			init: function () {
 				this.delimiter = ";";
@@ -411,7 +411,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 					isSelected[val] = true;
 				});
 
-				// Go through each &lt;option/&gt; element, if it has a value property (its a valid option), then 
+				// Go through each &lt;option/&gt; element, if it has a value property (its a valid option), then
 				// set its selected property if it was in the list of vals that were just set.
 				can.each(this.element[0].childNodes, function (option) {
 					if (option.value) {
@@ -421,7 +421,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 				});
 
 			},
-			// A helper function used by the 'change' handler below. Its purpose is to return an array of selected 
+			// A helper function used by the 'change' handler below. Its purpose is to return an array of selected
 			// values, like ["foo", "bar"]
 			get: function () {
 				var values = [],
@@ -475,59 +475,88 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 	// [abc]='{this}'
 	// [def]='{blah}'
 	can.view.attr(/\[[\w\.]+\]/, function(el, attrData) {
-		
+
 		var prop = removeBrackets(el.getAttribute(attrData.attributeName));
 		var name = removeBrackets(attrData.attributeName, '[', ']');
 
 		var viewModel = can.viewModel(el);
 		var scope = new can.view.Scope(viewModel);
-		
+
 		var computeData = scope.computeData(prop, {
 			args: []
 		}),
 			compute = computeData.compute;
-		
+
 		var handler = function (ev, newVal) {
 			// setup counter to prevent updating the scope with viewModel changes caused by scope updates.
 			attrData.scope.attr(name, newVal);
 		};
 		compute.bind("change", handler);
-		
+
 		attrData.scope.attr(name, compute());
-		
+
 		can.one.call(el, 'removed', function() {
 			compute.unbind("change", handler);
 		});
-		
+
 	});
-	
-	
+
+
 	can.view.attr(/#[\w\.]+/, function(el, attrData) {
-		
+
 		var prop = removeBrackets(el.getAttribute(attrData.attributeName)) || ".";
 		var name = can.camelize( attrData.attributeName.substr(1).toLowerCase() );
 
 		var viewModel = can.viewModel(el);
 		var scope = new can.view.Scope(viewModel);
 		var refs = attrData.scope.getRefs();
-		
+
 		var computeData = scope.computeData(prop, {
 			args: []
 		}),
 			compute = computeData.compute;
-		
+
 		var handler = function (ev, newVal) {
 			// setup counter to prevent updating the scope with viewModel changes caused by scope updates.
 			refs.attr(name, newVal);
 		};
 		compute.bind("change", handler);
-		
+
 		refs.attr(name, compute());
-		
+
 		can.one.call(el, 'removed', function() {
 			compute.unbind("change", handler);
 		});
-		
+
 	});
-	
+
+	can.view.attrValue(/{[\w\.]+}/, function(el, attrValueData){
+		var prop = removeBrackets(attrValueData.attributeValue) || ".";
+		var name = can.camelize(attrValueData.attributeName.toLowerCase());
+
+		// Only bind to simple elements and non can- attributes.
+		if(attrValueData.attributeName.indexOf("can-") === 0 ||
+			can.view.callbacks._tags[el.nodeName.toLowerCase()]) {
+			return;
+		}
+
+		var scope = attrValueData.scope;
+		var computeData = scope.computeData(prop, {
+			args: []
+		});
+		var compute = computeData.compute;
+
+		var handler = function(ev, newVal){
+			el[name] = newVal;
+		};
+		compute.bind("change", handler);
+
+		el[name] = compute();
+
+		can.one.call(el, "removed", function(){
+			compute.unbind("change", handler);
+		});
+
+	});
+
 });

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -734,13 +734,13 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 							 '</a>';
 		//var mustacheRenderer = can.mustache(templateString);
 		var stacheRenderer = can.stache(templateString);
-		
+
 		var obj = new can.Map({thing: 'stuff'});
-		
-		
+
+
 		stacheRenderer(obj);
 		ok(true, 'stache worked without errors');
-		
+
 	});
 
 	test("can-event throws an error when inside #if block (#1182)", function(){
@@ -885,12 +885,12 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		ta.appendChild(frag);
 		can.trigger(document.getElementById("click-me"), "click");
 	});
-	
+
 	test("by default can-EVENT calls with values, not computes", function(){
 		stop();
 		var ta = document.getElementById("qunit-fixture");
 		var template = can.stache("<div id='click-me' can-click='{map.method one map.two map.three}'></div>");
-		
+
 		var one = can.compute(1);
 		var three = can.compute(3);
 		var MyMap = can.Map.extend({
@@ -901,13 +901,13 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 				start();
 			}
 		});
-		
+
 		var map = new MyMap({"two": 2, "three": three});
-		
+
 		var frag = template({one: one, map: map});
 		ta.appendChild(frag);
 		can.trigger(document.getElementById("click-me"), "click");
-		
+
 	});
 
 	test('importing scope [prop]="{this}"', function() {
@@ -954,7 +954,7 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		equal(document.getElementById('qunit-fixture').childNodes[0].childNodes[1].innerHTML,
 			'Imported: David',  '{name} component scope imported into variable');
 	});
-	
+
 	test('live importing scope [prop]={scopeProp}', function(){
 		can.Component.extend({
 			tag: 'import-prop-scope',
@@ -978,17 +978,17 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		var frag = template({});
 		var importPropParent = frag.firstChild;
 		var importPropScope = importPropParent.getElementsByTagName("import-prop-scope")[0];
-		
+
 		can.viewModel(importPropScope).updateName();
-		
+
 		var importPropParentViewModel = can.viewModel(importPropParent);
-		
+
 		equal(importPropParentViewModel.attr("test"), "Justin", "got Justin");
-		
+
 		equal(importPropParentViewModel.attr("child"), can.viewModel(importPropScope), "got this");
-		
+
 	});
-	
+
 	test('reference values (#1700)', function(){
 		var data = new can.Map({person: {name: {}}});
 		can.Component.extend({
@@ -996,19 +996,19 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			template: can.stache('<span>{{referenceExport.name}}</span>'),
 			viewModel: {}
 		});
-		
+
 		var template = can.stache('{{#person}}{{#name}}'+
 			"<reference-export #reference-export/>"+
 			"{{/name}}{{/person}}<span>{{referenceExport.name}}</span>");
 		var frag = template(data);
-		
+
 		var refExport = can.viewModel(frag.firstChild);
 		refExport.attr("name","done");
-		
+
 		equal( frag.lastChild.firstChild.nodeValue, "done");
 		equal( frag.firstChild.firstChild.firstChild.nodeValue, "", "not done");
 	});
-	
+
 	test('reference values with <content> tag', function(){
 		can.Component.extend({
 			tag: "other-export",
@@ -1016,29 +1016,40 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 				name: "OTHER-EXPORT"
 			}
 		});
-	
+
 		can.Component.extend({
 			tag: "ref-export",
 			template: can.stache('<other-export #other-export/><content>{{otherExport.name}}</content>')
 		});
-		
+
 		// this should have otherExport name in the page
 		var t1 = can.stache("<ref-export></ref-export>");
-		
+
 		// this should not have anything in 'one', but something in 'two'
 		var t2 = can.stache("<form><other-export #other/><ref-export><b>{{otherExport.name}}</b><label>{{other.name}}</label></ref-export></form>");
-		
+
 		var f1 = t1();
 		equal(f1.firstChild.lastChild.nodeValue, "OTHER-EXPORT", "content");
-		
+
 		var f2 = t2();
 		var one = f2.firstChild.getElementsByTagName('b')[0];
 		var two = f2.firstChild.getElementsByTagName('label')[0];
-		
+
 		equal(one.firstChild.nodeValue, "", "external content, internal export");
 		equal(two.firstChild.nodeValue, "OTHER-EXPORT", "external content, external export");
 	});
-	
-	
-	
+
+	test("binding to arbitrary properties", function(){
+		var template = can.stache("<div hidden='{hidden}'></div>");
+		var map = new can.Map({ hidden: false });
+
+		var frag = template(map);
+
+		equal(frag.firstChild.hidden, false, "Initially not hidden");
+
+		map.attr("hidden", true);
+
+		equal(frag.firstChild.hidden, true, "Hidden now");
+	});
+
 });

--- a/view/callbacks/callbacks.js
+++ b/view/callbacks/callbacks.js
@@ -14,7 +14,7 @@ steal("can/util", "can/view",function(can){
 		} else {
 			var cb = attributes[attributeName];
 			if( !cb ) {
-				
+
 				for( var i = 0, len = regExpAttributes.length; i < len; i++) {
 					var attrMatcher = regExpAttributes[i];
 					if(attrMatcher.match.test(attributeName)) {
@@ -28,7 +28,9 @@ steal("can/util", "can/view",function(can){
 	};
 
 	var attributes = {},
+		attributeValues = {},
 		regExpAttributes = [],
+		regExpAttributeValues = [],
 		automaticCustomElementCharacters = /[-\:]/;
 
 	var tag = can.view.tag = function (tagName, tagHandler) {
@@ -43,7 +45,7 @@ steal("can/util", "can/view",function(can){
 				can.global.html5.elements += " " + tagName;
 				can.global.html5.shivDocument();
 			}
-	
+
 			tags[tagName.toLowerCase()] = tagHandler;
 		} else {
 			var cb = tags[tagName.toLowerCase()];
@@ -53,25 +55,54 @@ steal("can/util", "can/view",function(can){
 			}
 			return cb;
 		}
-		
+
 	};
 	var tags = {};
-	
+
+
+	var attrValue = can.view.attrValue = function (attributeValue, attrValueHandler) {
+		if(attrValueHandler) {
+			if (typeof attributeValue === "string") {
+				attributeValues[attributeValue] = attrValueHandler;
+			} else {
+				regExpAttributeValues.push({
+					match: attributeValue,
+					handler: attrValueHandler
+				});
+			}
+		} else {
+			var cb = attributeValues[attributeValue];
+			if( !cb ) {
+
+				for( var i = 0, len = regExpAttributeValues.length; i < len; i++) {
+					var attrMatcher = regExpAttributeValues[i];
+					if(attrMatcher.match.test(attributeValue)) {
+						cb = attrMatcher.handler;
+						break;
+					}
+				}
+			}
+			return cb;
+		}
+	};
+
+
 	can.view.callbacks = {
 		_tags: tags,
 		_attributes: attributes,
 		_regExpAttributes: regExpAttributes,
 		tag: tag,
 		attr: attr,
+		attrValue: attrValue,
 		// handles calling back a tag callback
 		tagHandler: function(el, tagName, tagData){
 			var helperTagCallback = tagData.options.attr('tags.' + tagName),
 				tagCallback = helperTagCallback || tags[tagName];
-	
+
 			// If this was an element like <foo-bar> that doesn't have a component, just render its content
 			var scope = tagData.scope,
 				res;
-				
+
 			if(tagCallback) {
 				var reads = can.__clearObserved();
 				res = tagCallback(el, tagData);
@@ -79,17 +110,17 @@ steal("can/util", "can/view",function(can){
 			} else {
 				res = scope;
 			}
-	
+
 			//!steal-remove-start
 			if (!tagCallback) {
 				can.dev.warn('can/view/scanner.js: No custom element found for ' + tagName);
 			}
 			//!steal-remove-end
-	
+
 			// If the tagCallback gave us something to render with, and there is content within that element
 			// render it!
 			if (res && tagData.subtemplate) {
-	
+
 				if (scope !== res) {
 					scope = scope.add(res);
 				}

--- a/view/target/target.js
+++ b/view/target/target.js
@@ -1,9 +1,9 @@
 /* jshint maxdepth:7*/
 steal("can/util", "can/view/elements.js",function(can, elements){
-	
+
 	var processNodes = function(nodes, paths, location){
 		var frag = document.createDocumentFragment();
-		
+
 		for(var i = 0, len = nodes.length; i < len; i++) {
 			var node = nodes[i];
 			frag.appendChild( processNode(node,paths,location.concat(i)) );
@@ -13,13 +13,13 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 		keepsTextNodes =  typeof document !== "undefined" && (function(){
 			var testFrag = document.createDocumentFragment();
 			var div = document.createElement("div");
-			
+
 			div.appendChild(document.createTextNode(""));
 			div.appendChild(document.createTextNode(""));
 			testFrag.appendChild(div);
-			
+
 			var cloned  = testFrag.cloneNode(true);
-			
+
 			return cloned.childNodes[0].childNodes.length === 2;
 		})(),
 		clonesWork = typeof document !== "undefined" && (function(){
@@ -86,13 +86,13 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 					}
 				});
 			}
-			
+
 			if(node.childNodes) {
 				can.each(node.childNodes, function(child){
 					copy.appendChild( cloneNode(child) );
 				});
 			}
-			
+
 			return copy;
 		};
 
@@ -114,7 +114,7 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 			}
 			return callback;
 		};
-		
+
 		if(nodeType === "object") {
 			if( node.tag ) {
 				if(namespacesWork && node.namespace) {
@@ -122,7 +122,7 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 				} else {
 					el = document.createElement(node.tag);
 				}
-				
+
 				if(node.attrs) {
 					for(var attrName in node.attrs) {
 						var value = node.attrs[attrName];
@@ -140,6 +140,11 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 						getCallback().callbacks.push({callback: node.attributes[i]});
 					}
 				}
+				if(node.attributeValues) {
+					for(i = 0, len = node.attributeValues.length; i < len; i++) {
+						getCallback().callbacks.push({callback: node.attributeValues[i]});
+					}
+				}
 				if(node.children && node.children.length) {
 					// add paths
 					if(callback) {
@@ -151,19 +156,19 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 				}
 			} else if(node.comment) {
 				el = document.createComment(node.comment);
-				
+
 				if(node.callbacks) {
 					for(i = 0, len = node.attributes.length; i < len; i++ ) {
 						getCallback().callbacks.push({callback: node.callbacks[i]});
 					}
 				}
 			}
-			
-			
+
+
 		} else if(nodeType === "string"){
 			el = document.createTextNode(node);
 		} else if(nodeType === "function") {
-			
+
 			if(keepsTextNodes) {
 				el = document.createTextNode("");
 				getCallback().callbacks.push({callback: node});
@@ -175,22 +180,22 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 					return node.apply(el,arguments );
 				}});
 			}
-			
+
 		}
 		return el;
 	}
-	
+
 	function hydratePath(el, pathData, args){
 		var path = pathData.path,
 			callbacks = pathData.callbacks,
 			paths = pathData.paths,
 			callbackData,
 			child = el;
-		
+
 		for(var i = 0, len = path.length; i < len; i++) {
 			child = child.childNodes[path[i]];
 		}
-		
+
 		for(i = 0, len = callbacks.length; i < len; i++) {
 			callbackData = callbacks[i];
 			callbackData.callback.apply(child, args );
@@ -219,7 +224,7 @@ steal("can/util", "can/view/elements.js",function(can, elements){
 		};
 	}
 	makeTarget.keepsTextNodes = keepsTextNodes;
-	
+
 	can.view.target = makeTarget;
 
 	return makeTarget;


### PR DESCRIPTION
This adds a can.view.attrValue function that can be used to define
callbacks based on an attribute's value.  This is used to do bindings
for things like `<div hidden="{hidden}"></div>` and then setting the element's property when the hidden property on the map changes.

This is not ready yet as it doesn't update the value (like a can.Map
		with a `hidden` property) when the element's properties change.

This is related to #1700