### PR TITLE
Handle a few sort plugin edge cases

### DIFF
--- a/util/batch/batch.js
+++ b/util/batch/batch.js
@@ -216,7 +216,8 @@ steal('can/util/can.js', function (can) {
 			// Don't send events if initalizing.
 			if (!item._init) {
 				event = typeof event === 'string' ? {
-					type: event
+					type: event,
+					batchNum: can.batch.batchNum
 				} : event;
 
 				if( currentBatchEvents) {


### PR DESCRIPTION
- Batched list operations fired events without a `batchNum` (#1707)

  Swapped out all of the `can.trigger`'s with `can.batch.trigger` and made it
  so that `can.batch.trigger` adds the `can.batch.batchNum` when creating an
  `event` object.

- Batched list operations evaluated insert index despite `batchNum` (#1706)

  Fixed the logic that returns/sorts based on the current event's `batchNum`

- `change` events caused list items to be swapped with same-value siblings (#1705)

  The default selection sort is kind of greedy in that it continues to
  search for an insert index until it finds an item with a greater value,
  or the end of the list. This means that it will move an item passed
  siblings of the same value every time the `_getInsertIndex` is evaluated.
  Modifying the algorithm to swap to items that are equal OR greater doesn't
  fix the issue either, it just reverses the direction. The fix was to
  check if the item to the right of its current position is the same value. If it is, 
  don't move it. It's fine where it's at. 

- `change` events evaluated insert index when irrelevant values changed (#1722 fix 1 of 2)

  Previously, `change` events would naively call `_getInsertIndex` even if
  the property that changed wasn't the comparator. This was inefficient since
  it resulted in a loop over the items in the list needlessly. Now the changed
  `attr` is compared to `comparator` on every `change` event. If `comparator`
  is a function OR the changed attr is a substring of the comparator value, the
  insert index is evaluated.

- Added a few tests to make development a bit easier