### PR TITLE
adds test for and fixes issue with object property computes

### DIFF
--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -289,8 +289,16 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 					return target.unbind(eventName || propertyName, handler);
 				};
 			} else {
-				this._get = can.proxy(this._get, target);
-				this._set = can.proxy(this._set, target);
+				this._get = function() {
+					return can.getObject(propertyName, [target]);
+				};
+				this._set = function(value) {
+					// allow setting properties n levels deep, if separated with dot syntax
+					var properties = propertyName.split("."),
+						leafPropertyName = properties.pop(),
+						targetProperty = can.getObject(properties.join('.'), [target]);
+					targetProperty[leafPropertyName] = value;
+				};
 			}
 		},
 

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -1384,4 +1384,46 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", "steal-qunit
 		equal(person._bindings, 0, "After unbinding no bindings");
 	});
 
+	test('compute bound to object property (#1719)', 4, function () {
+		var obj = {};
+		obj.foo = 'bar';
+
+		var value = can.compute(obj, 'foo', 'change');
+		equal(value(), 'bar', 'property retrieved correctly');
+
+		value('baz');
+		equal(obj.foo, 'baz', 'property changed correctly');
+
+		var handler = function(ev, newVal, oldVal) {
+			equal(newVal, 'qux', 'change handler newVal correct');
+			equal(oldVal, 'baz', 'change handler oldVal correct');
+		};
+		value.bind('change', handler);
+		value('qux');
+		value.unbind('change', handler);
+	});
+
+	test('compute bound to nested object property (#1719)', 4, function () {
+		var obj = {
+			prop: {
+				subprop: {
+					foo: 'bar'
+				}
+			}
+		};
+
+		var value = can.compute(obj, 'prop.subprop.foo', 'change');
+		equal(value(), 'bar', 'property retrieved correctly');
+
+		value('baz');
+		equal(obj.prop.subprop.foo, 'baz', 'property changed correctly');
+
+		var handler = function(ev, newVal, oldVal) {
+			equal(newVal, 'qux', 'change handler newVal correct');
+			equal(oldVal, 'baz', 'change handler oldVal correct');
+		};
+		value.bind('change', handler);
+		value('qux');
+		value.unbind('change', handler);
+	});
 });


### PR DESCRIPTION
Fixes #1719 . Provides a getter and setter compute interface for non-map-like targets.