### PR TITLE
Revert "Use [.] to represent a template's viewModel"

### DIFF
--- a/view/import/import.js
+++ b/view/import/import.js
@@ -28,7 +28,7 @@ steal("can/util", "can/view/callbacks", function(can){
 			callback(el, can.extend(tagData, {
 				scope: scope
 			}));
-			
+
 			can.data(can.$(el), "viewModel", importPromise);
 			can.data(can.$(el), "scope", importPromise);
 		}

--- a/view/import/import_test.js
+++ b/view/import/import_test.js
@@ -58,8 +58,8 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 			var res = template();
 			equal(res.childNodes[0].childNodes[0].nodeValue, "it worked", "Rendered with the can-tag");
 		});
-		
-		
+
+
 
 		asyncTest("can use an import's value", function(){
 			var template = "<can-import from='can/view/import/test/person' #person='{value}' />hello {{person.name}}";
@@ -73,13 +73,6 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 				equal(res.childNodes[2].nodeValue, "world", "Got the person.name from the import");
 				start();
 			});
-		});
-
-		test("specify the viewModel with [.] syntax", function(){
-			var template = "<can-import from='can/view/import/test/person' [.]='{value}' />";
-			var iai = getIntermediateAndImports(template);
-
-			equal(iai.ases.viewModel, "can/view/import/test/person", "viewModel set with [.] syntax");
 		});
 
 		asyncTest("can import a template and use it", function(){

--- a/view/parser/parser.js
+++ b/view/parser/parser.js
@@ -14,7 +14,7 @@ steal(function(){
 		});
 		return obj;
 	}
-	
+
 	function handleIntermediate(intermediate, handler){
 		for(var i = 0, len = intermediate.length; i < len; i++) {
 			var item = intermediate[i];

--- a/view/parser/parser_test.js
+++ b/view/parser/parser_test.js
@@ -246,16 +246,4 @@ steal("can/view/parser", "steal-qunit", function(parser){
 			["done",[]]
 		]));
 	});
-
-	test('allow [.]', function() {
-		parser('<p [.]="test"></p>', makeChecks([
-			["start", ["p", false]],
-			["attrStart", ["[.]"]],
-			["attrValue", ["test"]],
-			["attrEnd", ["[.]"]],
-			["end",["p"]],
-			["close",["p"]],
-			["done",[]]
-		]));
-	});
 });

--- a/view/stache/intermediate_and_imports.js
+++ b/view/stache/intermediate_and_imports.js
@@ -23,26 +23,23 @@ steal("can/view/stache/mustache_core.js", "can/view/parser",
 			attrStart: function( attrName ){
 				if(attrName === "from") {
 					inFrom = true;
-				} else if(inImport && attrName === "[.]") {
+				} else if(attrName === "as") {
 					inAs = true;
-					currentAs = "viewModel";
-					return false;
 				}
 			},
 			attrEnd: function( attrName ){
 				if(attrName === "from") {
 					inFrom = false;
-				} else if(inImport && attrName === "[.]") {
+				} else if(attrName === "as") {
 					inAs = false;
-					return false;
 				}
 			},
 			attrValue: function( value ){
 				if(inFrom && inImport) {
 					imports.push(value);
 					currentFrom = value;
-				} else if(inAs && currentAs === "viewModel") {
-					return false;
+				} else if(inAs && inImport) {
+					currentAs = value;
 				}
 			},
 			end: function(tagName){
@@ -51,7 +48,6 @@ steal("can/view/stache/mustache_core.js", "can/view/parser",
 					if(currentAs) {
 						ases[currentAs] = currentFrom;
 						currentAs = "";
-						inAs = false;
 					}
 				}
 			},


### PR DESCRIPTION
This reverts commit 7b6c9b3dad6710c4e1ccb6adddf369428e344b4f.

We are going to go back to a previous syntax that is:

```html
<can-import from="appstate" as="@viewModel" />
```