### PR TITLE
Split the “Application Foundations” into two parts

### DIFF
--- a/guides/getting-started-tutorial/application-design.md
+++ b/guides/getting-started-tutorial/application-design.md
@@ -1,0 +1,48 @@
+@page ApplicationDesign Application Design
+@parent Tutorial 2
+@disableTableOfContents
+
+@body
+
+<div class="getting-started">
+
+- - -
+**In this Chapter**
+ - Designing an Application
+- - -
+
+The first step in putting together a CanJS app is sketching out the various
+states of your application, as you understand them at the moment
+(requirements are always subject to change!),
+and any supporting elements you might need.
+
+We’ll be building a small application called “Place My Order”. Place My Order is a
+website that lets you select from available restaurants in your area, view their
+menus, and purchase items for delivery. For this sample application, we’ll keep
+things pretty simple. We won’t worry about registration, authentication, or
+payment processing. We’re just going to create an application with six states:
+
+1. Home
+2. Select a Restaurant
+3. View a Restaurant
+4. Order Form
+5. Confirmation
+6. View Order History
+
+And a few supporting objects:
+
+1. Menus
+2. Menu Items
+3. Restaurant List
+4. Cities
+5. States
+6. Orders
+7. Order History List
+
+- - -
+
+<span class="pull-left">[&lsaquo; Setup](Setup.html)</span>
+<span class="pull-right">[Constructors &rsaquo;](Constructors.html)</span>
+
+</div>
+

--- a/guides/getting-started-tutorial/components.md
+++ b/guides/getting-started-tutorial/components.md
@@ -1,5 +1,5 @@
 @page Components Getting to Know Components
-@parent Tutorial 3
+@parent Tutorial 4
 @disableTableOfContents
 
 @body

--- a/guides/getting-started-tutorial/constructors.md
+++ b/guides/getting-started-tutorial/constructors.md
@@ -1,5 +1,5 @@
-@page ApplicationFoundations Application Foundations
-@parent Tutorial 2
+@page Constructors Constructors
+@parent Tutorial 3
 @disableTableOfContents
 
 @body
@@ -8,39 +8,13 @@
 
 - - -
 **In this Chapter**
- - Application Overview
- - Understanding `can.Construct`
+ - Constructors in CanJS
+  - The `extend` function
+  - The `init` function
 - - -
 
-The first step in putting together a CanJS app is sketching out the various
-states of your application, as you understand them at the moment
-(requirements are always subject to change!),
-and any supporting elements you might need.
-
-We’ll be building a small application called "PlaceMyOrder". PlaceMyOrder is a
-website that lets you select from available restaurants in your area, view their
-menus, and purchase items for delivery. For this sample application, we’ll keep
-things pretty simple. We won’t worry about registration, authentication, or
-payment processing. We’re just going to create an application with three states:
-
-1. Restaurant
-2. Order Form
-3. Confirmation
-
-And a few supporting objects:
-
-1. Menus
-2. Menu Items
-3. Restaurant List
-
-The following pseudo UML diagram outlines the elements that comprise up our application:
-
-![](../can/guides/images/1_application_foundations/AppStateDiagram.png)
-
-## Constructors in CanJS
-
 Before we work with any of the objects in CanJS, it will be helpful for us to
-understand [can.Construct](../docs/can.Construct.html). We won't be working
+understand [can.Construct](../docs/can.Construct.html). We won’t be working
 with `can.Construct` directly. However, many of the objects in CanJS are derived from
 `can.Construct`. Understanding it, therefore, will make it easier for you to understand the
 concepts we're going to cover.
@@ -48,18 +22,18 @@ concepts we're going to cover.
 `can.Construct` provides a way to easily use the power of prototypal
 inheritance without worrying about hooking up all the particulars
 yourself. Without going into exhaustive detail, `can.Construct` contains
-a few functions we'll encounter frequently in other objects:
+a few functions we’ll encounter frequently in other objects:
 
 - Prototype
   - init
 - Static
   - extend
 
-We'll look at the extend function first.
+We’ll look at the extend function first.
 
-### The extend function
-`can.Construct`'s `extend` function is used to create
-"constructor functions". Constructor functions create instances of objects.
+## The extend function
+`can.Construct`’s `extend` function is used to create
+“constructor functions”. Constructor functions create instances of objects.
 The extend function can take up to three arguments:
 
 1. `name`: string
@@ -86,12 +60,12 @@ can.Construct.extend({
 });
 ```
 
-### The init function
+## The init function
 The `init` function is called whenever a new instance of a
-`can.Construct` is created. Init is where the bulk of your initialization code
-should go. Inside of the init function, the `this` keyword will refer to the
+`can.Construct` is created. `init` is where the bulk of your initialization code
+should go. Inside of the `init` function, the `this` keyword will refer to the
 new instance and `this` will contain the instance properties you pass to the
-constructor. A common thing to do in init is save the arguments passed into
+constructor. A common thing to do in `init` is save the arguments passed into
 the constructor. An example is below:
 
 ```
@@ -107,7 +81,7 @@ var actor = new Person('Abe', 'Vigoda');
 
 - - -
 
-<span class="pull-left">[&lsaquo; Setup](Setup.html)</span>
+<span class="pull-left">[&lsaquo; Application Design](ApplicationDesign.html)</span>
 <span class="pull-right">[Getting to Know Components &rsaquo;](Components.html)</span>
 
 </div>

--- a/guides/getting-started-tutorial/setup.md
+++ b/guides/getting-started-tutorial/setup.md
@@ -148,6 +148,6 @@ chapter to learn more.
 - - -
 
 <span class="pull-left">[&lsaquo; Getting Started](Tutorial.html)</span>
-<span class="pull-right">[Application Foundations &rsaquo;](ApplicationFoundations.html)</span>
+<span class="pull-right">[Application Design &rsaquo;](ApplicationDesign.html)</span>
 
 </div>


### PR DESCRIPTION
- Split the page into two separate pages because they cover two different subjects and aren’t dependent on each other.
- Use the correct apostrophe symbol
- Other spelling & grammar fixes