### PR TITLE
can.route.ready should set state in a Browser window

### DIFF
--- a/route/route.js
+++ b/route/route.js
@@ -414,7 +414,7 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 		ready: function (val) {
 			if (val !== true) {
 				can.route._setup();
-				if(!can.isNode) {
+				if(can.isBrowserWindow) {
 					can.route.setState();
 				}
 			}

--- a/util/can.js
+++ b/util/can.js
@@ -41,7 +41,7 @@ steal(function () {
 		return arr && arr[arr.length - 1];
 	};
 
-	
+
 	can.isDOM = function(el) {
 		return (el.ownerDocument || el) === can.global.document;
 	};
@@ -160,6 +160,10 @@ steal(function () {
 
 	can.isNode = typeof process === "object" &&
 		{}.toString.call(process) === "[object process]";
+
+	can.isBrowserWindow = typeof window !== "undefined" &&
+		typeof document !== "undefined" && typeof SimpleDOM === "undefined";
+
 
 	//!steal-remove-start
 	can.dev = {


### PR DESCRIPTION
We were only setting state if not in Node, but NW.js is a Node
environment and we want state to be set there. This updates the check to
isBrowserWindow instead, so state will be set in a browser environment
with a window and document.