### PR TITLE
Fixing return types for can.List filter & reverse

### DIFF
--- a/list/list.js
+++ b/list/list.js
@@ -673,7 +673,7 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 		 */
 		reverse: function() {
 			var list = [].reverse.call(can.makeArray(this));
-			this.replace(list);
+			return this.replace(list);
 		},
 
 		/**
@@ -838,7 +838,7 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 			return this;
 		},
 		filter: function (callback, thisArg) {
-			var filteredList = new can.List(),
+			var filteredList = new this.constructor(),
 				self = this,
 				filtered;
 			this.each(function(item, index, list){

--- a/list/list_test.js
+++ b/list/list_test.js
@@ -298,4 +298,21 @@ steal("can/util", "can/list", "can/test", "can/compute", "steal-qunit", function
 		list.splice(0, list.length, 'aa', 'cc');
 		deepEqual(list.attr(), ['aa', 'cc']);
 	});
+
+	test('filter returns same list type (#1744)', function() {
+		var ParentList = can.List.extend();
+		var ChildList = ParentList.extend();
+
+		var children = new ChildList([1,2,3]);
+
+		ok(children.filter(function() {}) instanceof ChildList);
+	});
+
+	test('reverse returns the same list instance (#1744)', function() {
+		var ParentList = can.List.extend();
+		var ChildList = ParentList.extend();
+
+		var children = new ChildList([1,2,3]);
+		ok(children.reverse() === children);
+	});
 });


### PR DESCRIPTION
Instances of a can.List should return the corresponding type of List when using filter & reverse. For example:

```js
var Todo = can.Map.extend();
var Todo.List = Todo.List.extend();

var todos = new Todo.List();
todos.filter() instanceof Todo.List; //should be true
todos.reverse() === todos; //should be true
```