### PR TITLE
Only attempt unbind when __bindEvents is defined

### DIFF
--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -792,4 +792,10 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 
 		comp('test');
 	});
+
+	test('Calling .unbind() on un-bound compute does not throw an error', function () {
+		var count =  can.compute(0);
+		count.unbind('change');
+		ok(true, 'No error was thrown');
+	});
 });

--- a/util/bind/bind.js
+++ b/util/bind/bind.js
@@ -27,6 +27,9 @@ steal('can/util', function (can) {
 		return this;
 	};
 	can.unbindAndTeardown = function (event, handler) {
+		if (!this.__bindEvents) {
+			return this;
+		}
 
 		var handlers = this.__bindEvents[event] || [];
 		var handlerCount = handlers.length;


### PR DESCRIPTION
An error is thrown if `unbind` is called on a compute that has no bindings. 

This PR addresses the issue by returning early when `__bindEvents` is falsy, as is done in  `event.js` here: https://github.com/bitovi/canjs/blob/master/event/event.js#L196-L198

Closes #1779