### PR TITLE
Travis new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js: 0.10
 before_script: node_modules/.bin/bower install


### PR DESCRIPTION
This is a small change to allow CanJS builds to run on the new Travis setup. Builds will start < 10 sec from commit as opposed to a longer wait time. Details are here: http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade