### PR TITLE
Use NodeList.prototype.item to get a childNode

### DIFF
--- a/util/inserted/inserted.js
+++ b/util/inserted/inserted.js
@@ -62,7 +62,7 @@ steal('can/util/can.js', function (can) {
 	can.insertBefore = function (el, child, ref, document) {
 		var children;
 		if (child.nodeType === 11) {
-			children = can.makeArray(child.childNodes);
+			children = can.makeArray(can.childNodes(child));
 		} else {
 			children = [child];
 		}

--- a/util/jquery/jquery.js
+++ b/util/jquery/jquery.js
@@ -236,35 +236,35 @@ steal('jquery', 'can/util/can.js', 'can/util/attr', "can/event", 'can/util/array
 			} else {
 				$.removeData(this, "canHasAttributesBindings");
 			}
-			
+
 		}
 	};
 
-	
+
 	// ## Fix build fragment.
 	// In IE8, we can pass jQuery a fragment and it removes newlines.
 	// This checks for that and replaces can.buildFragment with something
 	// that if only a single text node is returned, returns a fragment with
 	// a text node that is set to the content.
 	(function(){
-		
+
 		var text = "<-\n>",
 			frag = can.buildFragment(text, document);
 		if(frag.firstChild && (text !== frag.firstChild.nodeValue) ) {
-			
+
 			var oldBuildFragment  = can.buildFragment;
 			can.buildFragment = function(content, context){
 				var res = oldBuildFragment(content, context);
-				if(res.childNodes.length === 1 && res.childNodes[0].nodeType === 3) {
+				if(res.childNodes.length === 1 && res.childNodes.item(0).nodeType === 3) {
 					res.childNodes[0].nodeValue = content;
 				}
 				return res;
 			};
-			
+
 		}
-		
-		
-		
+
+
+
 	})();
 
 	$.event.special.inserted = {};

--- a/view/stache/html_section.js
+++ b/view/stache/html_section.js
@@ -1,6 +1,6 @@
 steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( can, target, utils, mustacheCore ) {
 
-	
+
 	var decodeHTML = typeof document !== "undefined" && (function(){
 		var el = document.createElement('div');
 		return function(html){
@@ -8,25 +8,25 @@ steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( c
 				return html.replace(/\r\n/g,"\n");
 			}
 			el.innerHTML = html;
-			return el.childNodes.length === 0 ? "" : el.childNodes[0].nodeValue;
+			return el.childNodes.length === 0 ? "" : el.childNodes.item(0).nodeValue;
 		};
 	})();
 	// ## HTMLSectionBuilder
 	//
 	// Contains a stack of HTMLSections.
 	// An HTMLSection is created everytime a subsection is found. For example:
-	// 
+	//
 	//     {{#if items}} {{#items}} X
 	//
-	// At the point X was being processed, their would be 2 HTMLSections in the 
+	// At the point X was being processed, their would be 2 HTMLSections in the
 	// stack.  One for the content of `{{#if items}}` and the other for the
 	// content of `{{#items}}`
 	var HTMLSectionBuilder = function(){
 		this.stack = [new HTMLSection()];
 	};
-	
+
 	can.extend(HTMLSectionBuilder.prototype,utils.mixins);
-	
+
 	can.extend(HTMLSectionBuilder.prototype,{
 		startSubSection: function(process){
 			var newSection = new HTMLSection(process);
@@ -60,7 +60,7 @@ steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( c
 		},
 		compile: function(){
 			var compiled = this.stack.pop().compile();
-			
+
 			return function(scope, options, nodeList){
 				if ( !(scope instanceof can.view.Scope) ) {
 					scope = can.view.Scope.refsScope().add(scope || {});
@@ -78,7 +78,7 @@ steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( c
 			return this.last().pop();
 		}
 	});
-	
+
 	var HTMLSection = function(process){
 		this.data = "targetData";
 		this.targetData = [];
@@ -139,7 +139,7 @@ steal("can/util","can/view/target","./utils.js","./mustache_core.js",function( c
 			return !this.targetData.length;
 		}
 	});
-	
+
 	return HTMLSectionBuilder;
-	
+
 });


### PR DESCRIPTION
Instead of:

```js
var node = parent.childNodes[0];
```

we always need to do:

```js
var node = parent.childNodes.item(0);
```

To support the virtual DOM environment.