### PR TITLE
Allow loading in a web worker

### DIFF
--- a/util/can.js
+++ b/util/can.js
@@ -1,6 +1,8 @@
 /* global global: false */
 steal(function () {
 	/* global GLOBALCAN */
+	/* global self */
+	/* global WorkerGlobalScope */
 	var glbl = typeof window !== "undefined" ? window :
 		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self : global;
 

--- a/util/can.js
+++ b/util/can.js
@@ -1,7 +1,8 @@
 /* global global: false */
 steal(function () {
 	/* global GLOBALCAN */
-	var glbl = typeof window !== "undefined" ? window : global;
+	var glbl = typeof window !== "undefined" ? window :
+		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self : global;
 
 	var can = {};
 	if (typeof GLOBALCAN === 'undefined' || GLOBALCAN !== false) {

--- a/util/vdom/vdom.js
+++ b/util/vdom/vdom.js
@@ -1,6 +1,6 @@
 // Everything CanJS+jquery app needs to run to pass
 // if you are doing almost everything with the can.util layer
-steal("can-simple-dom", "./build_fragment/make_parser", function(simpleDOM, makeParser){
+steal("can/util/can.js", "can-simple-dom", "./build_fragment/make_parser", function(can, simpleDOM, makeParser){
 
 	var document = new simpleDOM.Document();
 	var serializer = new simpleDOM.HTMLSerializer(simpleDOM.voidMap);
@@ -29,6 +29,7 @@ steal("can-simple-dom", "./build_fragment/make_parser", function(simpleDOM, make
 		Object.defineProperty(simpleDOM.Element.prototype, "innerHTML", descriptor());
 		Object.defineProperty(simpleDOM.Element.prototype, "outerHTML", descriptor(true));
 	}
+	var global = can.global;
 	global.document = document;
 	global.window = global;
 	global.addEventListener = function(){};


### PR DESCRIPTION
To make it possible for can to be loaded in a Web Worker we need to set
can.global to the correct object, `self` and use it in can/util/vdom.