### PR TITLE
Allow CanJS to run in a web worker.

### DIFF
--- a/route/route.js
+++ b/route/route.js
@@ -414,7 +414,7 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 		ready: function (val) {
 			if (val !== true) {
 				can.route._setup();
-				if(can.isBrowserWindow) {
+				if(can.isBrowserWindow || can.isWebWorker) {
 					can.route.setState();
 				}
 			}
@@ -550,7 +550,8 @@ steal('can/util', 'can/map', 'can/list','can/util/string/deparam', function (can
 				// For hashbased routing, it's everything after the #, for
 				// pushState it's configurable
 				matchingPartOfURL: function () {
-					return location.href.split(/#!?/)[1] || "";
+					var loc = can.route.location || location;
+					return loc.href.split(/#!?/)[1] || "";
 				},
 				// gets called with the serialized can.route data after a route has changed
 				// returns what the url has been updated to (for matching purposes)

--- a/util/can.js
+++ b/util/can.js
@@ -166,6 +166,8 @@ steal(function () {
 
 	can.isBrowserWindow = typeof window !== "undefined" &&
 		typeof document !== "undefined" && typeof SimpleDOM === "undefined";
+	can.isWebWorker = typeof WorkerGlobalScope !== "undefined" &&
+		(self instanceof WorkerGlobalScope);
 
 
 	//!steal-remove-start

--- a/util/jquery/jquery.js
+++ b/util/jquery/jquery.js
@@ -256,7 +256,7 @@ steal('jquery', 'can/util/can.js', 'can/util/attr', "can/event", 'can/util/array
 			can.buildFragment = function(content, context){
 				var res = oldBuildFragment(content, context);
 				if(res.childNodes.length === 1 && res.childNodes.item(0).nodeType === 3) {
-					res.childNodes[0].nodeValue = content;
+					res.childNodes.item(0).nodeValue = content;
 				}
 				return res;
 			};

--- a/util/vdom/vdom.js
+++ b/util/vdom/vdom.js
@@ -1,7 +1,6 @@
 // Everything CanJS+jquery app needs to run to pass
 // if you are doing almost everything with the can.util layer
 steal("can/util/can.js", "can-simple-dom", "./build_fragment/make_parser", function(can, simpleDOM, makeParser){
-
 	var document = new simpleDOM.Document();
 	var serializer = new simpleDOM.HTMLSerializer(simpleDOM.voidMap);
 	var parser = makeParser(document);

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -366,7 +366,6 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			},
 			// This event is triggered by the DOM.  If a change event occurs, we must set the value of the compute (options.value).
 			"change": function () {
-
 				if (this.isCheckbox) {
 					// If the checkbox is checked and can-true-value was used, set value to the string value of can-true-value.  If
 					// can-false-value was used and checked is false, set value to the string value of can-false-value.
@@ -488,7 +487,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			childScope = new can.view.Scope(childViewModel),
 			computeData = childScope.computeData(prop, {
 				args: [],
-				
+
 			}),
 			childCompute = computeData.compute,
 			parentViewModel = attrData.scope.getViewModel();
@@ -513,12 +512,12 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 			name = can.camelize( attrData.attributeName.substr(1).toLowerCase() ),
 			twoWayBind = true;
 
-		
+
 		if(prop.charAt(0) === "{") {
 			twoWayBind = false;
 			prop = removeBrackets( prop );
 		}
-		
+
 		var viewModel = can.viewModel(el);
 		var scope = new can.view.Scope(viewModel);
 		var refs = attrData.scope.getRefs();
@@ -537,7 +536,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 
 		var initialValue = compute();
 		refs.attr(name, initialValue === undefined ? null : initialValue);
-		
+
 		if(twoWayBind) {
 			var twoWayHandler = function(ev, newVal){
 				compute(newVal);


### PR DESCRIPTION
This fixes CanJS so that it can be ran in a Web Worker context. The key
changes:

* Added a `can.isWebWorker` so that we can call `setState()` in can.route.
* can.route looks for `can.route.location` first when updating the state, because in Worker Rendering we set a can.route.location.