### PR TITLE
Shim window.history when in vdom environment.

### DIFF
--- a/util/vdom/vdom.js
+++ b/util/vdom/vdom.js
@@ -43,4 +43,8 @@ steal("can/util/can.js", "can-simple-dom", "./build_fragment/make_parser", funct
 		search: '',
 		hash: ''
 	};
+	global.history = {
+		pushState: can.k,
+		replaceState: can.k
+	};
 });


### PR DESCRIPTION
This shims window.history when operating in a vdom environment so that
can/route/pushstate will load. It's up to other libraries to provide the
functionality of pushState/replaceState.