### PR TITLE
<select> with undefined can-value should not be blank in Chrome

### DIFF
--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -312,8 +312,16 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 				return;
 			}
 			var val = this.options.value();
+			// For https://github.com/bitovi/canjs/issues/1679. We don't want to set
+			// null or undefined on select fields because Chrome shows it as blank
+			if(val == null && this.element[0].nodeName.toUpperCase() !== "SELECT") {
+				val = '';
+			}
+
 			// Set the element's value to match the attribute that was passed in
-			this.element[0].value = (val == null ? '' : val);
+			if(val != null) {
+				this.element[0].value = val;
+			}
 		},
 		// If the input value changes, this will set the live bound data to reflect the change.
 			// If the input value changes, this will set the live bound data to reflect the change.

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -869,4 +869,19 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 			}, 10);
 		}, 10);
 	});
+
+	test("<select can-value={value}> with undefined value selects option without value", function () {
+
+		var template = can.view.stache("<select can-value='opt'><option>Loading...</option></select>");
+
+		var map = new can.Map();
+
+		var frag = template(map);
+
+		var ta = document.getElementById("qunit-fixture");
+		ta.appendChild(frag);
+
+		var select = ta.childNodes[0];
+		QUnit.equal(select.selectedIndex, 0, 'Got selected index');
+	});
 });


### PR DESCRIPTION
Closes #1679