### PR TITLE
Make sure component init event handlers are not unbound

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -282,22 +282,9 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 				this._control = new this.constructor.Control(el, {
 					// Pass the viewModel to the control so we can listen to it's changes from the controller.
 					scope: this.scope,
-					viewModel: this.scope
+					viewModel: this.scope,
+					destroy: callTeardownFunctions
 				});
-
-				// If control has a 'destroy' event, unbind the properties after its called #1415
-				if(this._control && this._control.destroy){
-					var oldDestroy = this._control.destroy;
-					this._control.destroy = function(){
-						oldDestroy.apply(this, arguments);
-						callTeardownFunctions();
-					};
-					this._control.on();
-				} else {
-					can.bind.call(el, "removed", function () {
-						callTeardownFunctions();
-					});
-				}
 
 				// ## Rendering
 
@@ -478,6 +465,11 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 			// Call `can.Control.prototype.off` function on this instance to cleanup the bindings.
 			can.Control.prototype.off.apply(this, arguments);
 			this._bindings.readyComputes = {};
+		},
+		destroy: function() {
+			if(typeof this.options.destroy === 'function') {
+				this.options.destroy.apply(this, arguments);
+			}
 		}
 	});
 

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1558,6 +1558,30 @@ steal("can", "can/map/define", "can/component", "can/view/stache" ,"can/route", 
 
 	});
 
+	test("attach events on init", function(){
+		expect(2);
+		can.Component.extend({
+			tag: 'app-foo',
+			template: can.stache('<div>click me</div>'),
+			events: {
+				init: function(){
+					this.on("div", 'click', 'doSomethingfromInit');
+				},
+				inserted: function(){
+					this.on("div", 'click', 'doSomethingfromInserted');
+				},
+				doSomethingfromInserted: function(){
+					ok(true, "bound in inserted");
+				},
+				doSomethingfromInit: function(){
+					ok(true, "bound in init");
+				}
+			}
+		});
+		can.append( can.$("#qunit-fixture"), can.stache("<app-foo></app-foo>")({}));
+		can.trigger(can.$('#qunit-fixture div'), 'click');
+	});
+
 	if(can.isFunction(Object.keys)) {
 		test('<content> node list cleans up properly as direct child (#1625, #1627)', 2, function() {
 			var size = Object.keys(can.view.nodeLists.nodeMap).length;


### PR DESCRIPTION
Closes #1623 which was caused by a regression introduced in #1422 (fix for issue #1415) calling `this._control.on()` removed all event handlers set up during `init`. Now we just pass a function to the Component control that will be called at the right time in `destroy`.