### PR TITLE
Pass parent scope helpers to helper's options

### DIFF
--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -300,7 +300,9 @@ steal("can/util",
 					contexts: scope,
 					hash: hash,
 					nodeList: nodeList,
-					exprData: exprData
+					exprData: exprData,
+					options: options,
+					helpers: options
 				});
 
 				args.push(helperOptions);


### PR DESCRIPTION
Pass parent scope helpers to helper's options. Related to this issue https://github.com/bitovi/canjs/issues/1783