### PR TITLE
Build: properly normalize 'exports' and 'module'

### DIFF
--- a/build/config_stealPluginify.js
+++ b/build/config_stealPluginify.js
@@ -19,6 +19,10 @@ var	allModuleNames = _.map(modules,function(mod){
 	};
 
 var canNormalize = function(name, depLoad, curName){
+	if(!depLoad) {
+		return name;
+	}
+
 	if( depLoad.address.indexOf("node_modules") >= 0 ) {
 		return denpm(name);
 	}
@@ -216,7 +220,7 @@ module.exports = function(){
 								moduleName = "./"+moduleName
 							}
 							return moduleName;
-						} 
+						}
 						if(depName === "jquery/jquery") {
 							return "jquery"
 						}
@@ -228,9 +232,9 @@ module.exports = function(){
 						if(isNpm(moduleName)) {
 							moduleName = moduleName.substr(moduleName.lastIndexOf("#")+1);
 						}
-						
+
 						name = moduleName.replace("can/","")+".js";
-						
+
 						return path.join(__dirname,"..", "dist", "cjs", name);
 					},
 					format: "cjs",

--- a/test/amd/dojo.html
+++ b/test/amd/dojo.html
@@ -29,7 +29,8 @@
             "paths": {
                 "can": "dist/amd/can",
                 "dojo": "bower_components/dojo",
-                "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom"
+                "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom",
+                "micro-location": "node_modules/can-simple-dom/node_modules/micro-location/lib/micro-location"
             },
             "map": {
                 "*": {

--- a/test/amd/jquery-2.html
+++ b/test/amd/jquery-2.html
@@ -30,6 +30,7 @@
                 "can": "dist/amd/can",
                 "dojo": "bower_components/dojo",
                 "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom",
+                "micro-location": "node_modules/can-simple-dom/node_modules/micro-location/lib/micro-location",
                 "jquery": "bower_components/jquery/dist/jquery"
             },
             "map": {

--- a/test/amd/jquery.html
+++ b/test/amd/jquery.html
@@ -30,6 +30,7 @@
                 "can": "dist/amd/can",
                 "dojo": "bower_components/dojo",
                 "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom",
+                "micro-location": "node_modules/can-simple-dom/node_modules/micro-location/lib/micro-location",
                 "jquery": "node_modules/jquery/dist/jquery"
             },
             "map": {

--- a/test/amd/mootools.html
+++ b/test/amd/mootools.html
@@ -30,6 +30,7 @@
                 "can": "dist/amd/can",
                 "dojo": "bower_components/dojo",
                 "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom",
+                "micro-location": "node_modules/can-simple-dom/node_modules/micro-location/lib/micro-location",
                 "mootools": "bower_components/mootools/dist/mootools-core"
             },
             "map": {

--- a/test/amd/yui.html
+++ b/test/amd/yui.html
@@ -30,6 +30,7 @@
                 "can": "dist/amd/can",
                 "dojo": "bower_components/dojo",
                 "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom",
+                "micro-location": "node_modules/can-simple-dom/node_modules/micro-location/lib/micro-location",
                 "yui": "util/yui/yui-3.7.3"
             },
             "map": {

--- a/test/amd/zepto.html
+++ b/test/amd/zepto.html
@@ -30,6 +30,7 @@
                 "can": "dist/amd/can",
                 "dojo": "bower_components/dojo",
                 "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom",
+                "micro-location": "node_modules/can-simple-dom/node_modules/micro-location/lib/micro-location",
                 "zepto": "bower_components/zepto/zepto"
             },
             "map": {

--- a/test/templates/__configuration__-amd.html.ejs
+++ b/test/templates/__configuration__-amd.html.ejs
@@ -27,7 +27,8 @@
             paths : {
               can: "dist/amd/can",
               "dojo": "bower_components/dojo",
-              "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom"
+              "simple-dom": "node_modules/can-simple-dom/dist/amd/simple-dom",
+              "micro-location": "node_modules/can-simple-dom/node_modules/micro-location/lib/micro-location"
             },
             map : {
                 '*' : {


### PR DESCRIPTION
AMD modules can have dependencies like 'exports' and 'module' that do
not have a `load` object, our canNormalize was not expecting this and so
was throwing an error. The fix is to just return the name when there is
no depLoad.