### PR TITLE
Pass options to helpers

### DIFF
--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -300,7 +300,9 @@ steal("can/util",
 					contexts: scope,
 					hash: hash,
 					nodeList: nodeList,
-					exprData: exprData
+					exprData: exprData,
+					options: options,
+					helpers: options
 				});
 
 				args.push(helperOptions);


### PR DESCRIPTION
This is so helpers can pass the parent helpers to child templates.
Thanks @whitecolor. Fixes #1783