### PR TITLE
Switch helper

### DIFF
--- a/view/stache/doc/helpers/case.md
+++ b/view/stache/doc/helpers/case.md
@@ -1,0 +1,21 @@
+@function can.stache.helpers.case {{#case expr}}
+@parent can.stache.htags 14
+
+@signature `{{#case expr}}BLOCK{{/case}}`
+
+Renders the `BLOCK` when `expr` matches the `expr` provided in the parent [can.stache.helpers.switch].
+
+@param {can.stache.expression} expr An expression or key that references a value.
+
+@param {can.stache} BLOCK a template that will render if the case clause resolves.
+
+@return {DocumentFragment} A fragment, possibly containing the rendered `BLOCK`.
+
+@body
+
+The `case` helper is contextual inside of a [can.stache.helpers.switch] block. The parent switch contains an `expr` that will be matched against the case `expr` and if they are equal the block will be returned.
+
+For more information on how `{{#case}}` is used check:
+
+- [can.stache.helpers.switch {{#switch expr}}]
+- [can.stache.helpers.default {{#default}}]

--- a/view/stache/doc/helpers/default.md
+++ b/view/stache/doc/helpers/default.md
@@ -1,0 +1,19 @@
+@function can.stache.helpers.default {{#default}}
+@parent can.stache.htags 15
+
+@signature `{{#default}}BLOCK{{/default}}`
+
+Renders the `BLOCK` if no [can.stache.helpers.case] blocks within the switch resolved.
+
+@param {can.stache} BLOCK a template to be rendered.
+
+@return {DocumentFragment} A fragment, containing the rendered block.
+
+@body
+
+The `default` helper is contextual inside of a [can.stache.helpers.switch] block. It acts as a fall-through in case none of the [can.stache.helpers.case] helpers resolved.
+
+For more information on how `{{#default}}` is used check:
+
+- [can.stache.helpers.switch {{#switch expr}}]
+- [can.stache.helpers.case {{#case expr}}]

--- a/view/stache/doc/helpers/switch.md
+++ b/view/stache/doc/helpers/switch.md
@@ -1,0 +1,34 @@
+@function can.stache.helpers.switch {{#switch expr}}
+@parent can.stache.htags 13
+
+@signature `{{#switch expr}}BLOCK{{/switch}}`
+
+Renders the `BLOCK` with contextual [can.stache.helpers.case] and [can.stache.helpers.default] helpers.
+
+@param {can.stache.expression} expr An expression or key that references a value that will be switched on.
+
+@param {can.stache} BLOCK a template that is rendered, uses [can.stache.helpers.case] and [can.stache.helpers.default] helpers to match `expr`.
+
+@return {DocumentFragment} A fragment containing the rendered `BLOCK`.
+
+@body
+
+The `switch` helper is used to render a block where one of several cases matches expr. It works just like a JavaScript switch.
+
+
+	{{#switch page}}
+
+		{{#case "cart"}}
+			<can-import from="cart">
+				<cart-page></cart-page>
+			</can-import>
+		{{/case}}
+
+		{{#default}}
+			<can-import from="home">
+				<home-page></home-page>
+			</can-import>
+		{{/default}}
+
+	{{/switch}}
+

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -1,6 +1,6 @@
 steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 	live = live || can.view.live;
-	
+
 	var resolve = function (value) {
 		if (utils.isObserveLike(value) && utils.isArrayLike(value) && value.attr('length')) {
 			return value;
@@ -10,16 +10,16 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			return value;
 		}
 	};
-	
+
 	var helpers = {
 		"each": function(items, options){
-			
+
 			var resolved = resolve(items),
 				result = [],
 				keys,
 				key,
 				i;
-			
+
 			if( resolved instanceof can.List ) {
 				return function(el){
 					// make a child nodeList inside the can.view.live.html nodeList
@@ -28,18 +28,18 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 					nodeList.expression = "live.list";
 					can.view.nodeLists.register(nodeList, null, options.nodeList);
 					can.view.nodeLists.update(options.nodeList, [el]);
-					
+
 					var cb = function (item, index, parentNodeList) {
-								
+
 						return options.fn(options.scope.add({
 								"@index": index
 							}).add(item), options.options, parentNodeList);
-							
+
 					};
 					live.list(el, items, cb, options.context, el.parentNode, nodeList);
 				};
 			}
-			
+
 			var expr = resolved;
 
 			if ( !! expr && utils.isArrayLike(expr)) {
@@ -67,10 +67,10 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 						})
 						.add(expr[key])));
 				}
-				
+
 			}
 			return result;
-			
+
 		},
 		"@index": function(offset, options) {
 			if (!options) {
@@ -145,9 +145,26 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			// Get the argument before that.
 			var data = arguments.length === 2 ? this : arguments[1];
 			return function(el){
-				
+
 				can.data( can.$(el), attr, data || this.context );
 			};
+		},
+		'switch': function(expression, options){
+			var found = false;
+			var newOptions = options.helpers.add({
+				case: function(value, options){
+					if(resolve(expression) == resolve(value)) {
+						found = true;
+						return options.fn(options.scope || this);
+					}
+				},
+				default: function(options){
+					if(!found) {
+						return options.fn(options.scope || this);
+					}
+				}
+			});
+			return options.fn(options.scope, newOptions);
 		}
 	};
 
@@ -170,5 +187,5 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			}
 		}
 	};
-	
+
 });

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -153,7 +153,7 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			var found = false;
 			var newOptions = options.helpers.add({
 				case: function(value, options){
-					if(resolve(expression) == resolve(value)) {
+					if(resolve(expression) === resolve(value)) {
 						found = true;
 						return options.fn(options.scope || this);
 					}

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4127,6 +4127,37 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 
 			equal(frag.firstChild.nodeValue, "hello there", "partial rendered");
 		});
+
+		test("Handlebars helper: switch/case", function() {
+			var expected;
+			var t = {
+				template: '{{#switch ducks}}{{#case "10"}}10 ducks{{/case}}' +
+					'{{#default}}Not 10 ducks{{/default}}{{/switch}}',
+				expected: "10 ducks",
+				data: {
+					ducks: '10',
+					tenDucks: function() {
+						return '10'
+					}
+				},
+				liveData: new can.Map({
+					ducks: '10',
+					tenDucks: function() {
+						return '10'
+					}
+				})
+			};
+
+			expected = t.expected.replace(/&quot;/g, '&#34;').replace(/\r\n/g, '\n');
+			deepEqual(getText(t.template, t.data), expected);
+
+			deepEqual(getText(t.template, t.liveData), expected);
+
+			t.data.ducks = 5;
+
+			deepEqual(getText(t.template, t.data), 'Not 10 ducks');
+		});
+
 	}
 
 


### PR DESCRIPTION
This pr implements the switch helper. It can be used like:

```handlebars
{{#switch page}}

	{{#case "cart"}}
		<can-import from="cart">
			<cart-page></cart-page>
		</can-import>
	{{/case}}

	{{#default}}
		<can-import from="home">
			<home-page></home-page>
		</can-import>
	{{/default}}

{{/switch}}
```

Documentation included.

Closes #1264