### PR TITLE
Pass module as a helper for System compiled stache templates

### DIFF
--- a/util/can.js
+++ b/util/can.js
@@ -130,11 +130,13 @@ steal(function () {
 		}
 	};
 
-	can["import"] = function(moduleName) {
+	can["import"] = function(moduleName, parentName) {
 		var deferred = new can.Deferred();
 
 		if(typeof window.System === "object" && can.isFunction(window.System["import"])) {
-			window.System["import"](moduleName).then(can.proxy(deferred.resolve, deferred),
+			window.System["import"](moduleName, {
+				name: parentName
+			}).then(can.proxy(deferred.resolve, deferred),
 				can.proxy(deferred.reject, deferred));
 		} else if(window.define && window.define.amd){
 

--- a/view/import/import.js
+++ b/view/import/import.js
@@ -2,9 +2,15 @@ steal("can/util", "can/view/callbacks", function(can){
 
 	can.view.tag("can-import", function(el, tagData){
 		var moduleName = el.getAttribute("from");
+
+		// If the module is part of the helpers pass that into can.import
+		// as the parentName
+		var templateModule = tagData.options.attr("helpers.module");
+		var parentName = templateModule ? templateModule.id : undefined;
+
 		var importPromise;
 		if(moduleName) {
-			importPromise = can["import"](moduleName);
+			importPromise = can["import"](moduleName, parentName);
 		} else {
 			importPromise = can.Deferred().reject("No moduleName provided").promise();
 		}

--- a/view/import/import_test.js
+++ b/view/import/import_test.js
@@ -83,7 +83,7 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 
 				// Import will happen async
 				can["import"]("can/view/import/test/other.stache!").then(function(){
-					equal(frag.childNodes[1].firstChild.nodeValue, "hi there", "Partial was renderered right after the can-import");
+					equal(frag.childNodes[3].firstChild.nodeValue, "hi there", "Partial was renderered right after the can-import");
 
 					QUnit.start();
 				});
@@ -106,7 +106,7 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 				var frag = renderer();
 
 				can["import"]("can/view/import/test/other.stache!").then(function(){
-					equal(frag.childNodes[0].childNodes[0].firstChild.nodeValue, "hi there", "Partial worked with can-tag");
+					equal(frag.childNodes[0].childNodes[2].firstChild.nodeValue, "hi there", "Partial worked with can-tag");
 
 					QUnit.start();
 				});

--- a/view/import/test/other.stache
+++ b/view/import/test/other.stache
@@ -1,1 +1,3 @@
+<can-import from="./thing" />
+
 <span>hi there</span>

--- a/view/import/test/thing.js
+++ b/view/import/test/thing.js
@@ -1,0 +1,1 @@
+module.exports = "hello";

--- a/view/stache/system.js
+++ b/view/stache/system.js
@@ -3,12 +3,25 @@ steal("can/view/stache", "can/view/stache/intermediate_and_imports.js",function(
 
 	function translate(load) {
 		var intermediateAndImports = getIntermediateAndImports(load.source);
-		
-		intermediateAndImports.imports.unshift('can/view/stache/stache');
-		
-		return "define("+JSON.stringify(intermediateAndImports.imports)+",function(stache){" +
-			"return stache(" + JSON.stringify(intermediateAndImports.intermediate) + ")" +
-		"})";
+
+		intermediateAndImports.imports.unshift("can/view/stache/stache");
+		intermediateAndImports.imports.unshift("module");
+
+		return template(intermediateAndImports.imports,
+										intermediateAndImports.intermediate);
+	}
+
+	function template(imports, intermediate){
+		imports = JSON.stringify(imports);
+		intermediate = JSON.stringify(intermediate);
+
+		return "define("+imports+",function(module, stache){\n" +
+			"\tvar renderer = stache(" + intermediate + ");\n" +
+			"\treturn function(scope, options){\n" +
+			"\t\tvar moduleOptions = { module: module };\n" +
+			"\t\treturn renderer(scope, options ? options.add(moduleOptions) : moduleOptions);\n" +
+			"\t};\n" +
+		"});";
 	}
 
 	return {


### PR DESCRIPTION
This will allow `<can-import from="./other.stache" />`, module importing
from modules relative to the template. Closes #1817