### PR TITLE
Implement ~ helper

### DIFF
--- a/util/can.js
+++ b/util/can.js
@@ -130,6 +130,49 @@ steal(function () {
 		}
 	};
 
+
+	var parseURI = function(url){
+			var m = String(url).replace(/^\s+|\s+$/g, '').match(/^([^:\/?#]+:)?(\/\/(?:[^:@]*(?::[^:@]*)?@)?(([^:\/?#]*)(?::(\d*))?))?([^?#]*)(\?[^#]*)?(#[\s\S]*)?/);
+				// authority = '//' + user + ':' + pass '@' + hostname + ':' port
+			return (m ? {
+				href     : m[0] || '',
+				protocol : m[1] || '',
+				authority: m[2] || '',
+				host     : m[3] || '',
+				hostname : m[4] || '',
+				port     : m[5] || '',
+				pathname : m[6] || '',
+				search   : m[7] || '',
+				hash     : m[8] || ''
+			} : null);
+		};
+
+	can.joinURIs = function(base, href) {
+		function removeDotSegments(input) {
+			var output = [];
+			input.replace(/^(\.\.?(\/|$))+/, '')
+				.replace(/\/(\.(\/|$))+/g, '/')
+				.replace(/\/\.\.$/, '/../')
+				.replace(/\/?[^\/]*/g, function (p) {
+					if (p === '/..') {
+						output.pop();
+					} else {
+						output.push(p);
+					}
+				});
+			return output.join('').replace(/^\//, input.charAt(0) === '/' ? '/' : '');
+		}
+
+		href = parseURI(href || '');
+		base = parseURI(base || '');
+
+		return !href || !base ? null : (href.protocol || base.protocol) +
+			(href.protocol || href.authority ? href.authority : base.authority) +
+			removeDotSegments(href.protocol || href.authority || href.pathname.charAt(0) === '/' ? href.pathname : (href.pathname ? ((base.authority && !base.pathname ? '/' : '') + base.pathname.slice(0, base.pathname.lastIndexOf('/') + 1) + href.pathname) : base.pathname)) +
+				(href.protocol || href.authority || href.pathname ? href.search : (href.search || base.search)) +
+				href.hash;
+	};
+
 	can["import"] = function(moduleName, parentName) {
 		var deferred = new can.Deferred();
 

--- a/view/stache/doc/helpers/tilde.md
+++ b/view/stache/doc/helpers/tilde.md
@@ -1,0 +1,25 @@
+@function can.stache.helpers.tilde {{~ args}}
+@parent can.stache.htags 16
+
+@signature `{{~ expr}}`
+
+Return an application-relative url for a resource.
+
+@param {can.stache.expression} [expr...] An expression or key that references a value within the current or parent scope.
+
+@return {String} An application-relative url.
+
+@body
+
+The `~` helper is used to create urls within your application for static resources, such as images. An example usage:
+
+    {{~ "hello/" name ".png"}}
+
+Where `name` is a scope value, this might return `http://example.com/app/hello/world.png` if the application is `http://example.com/app`.
+
+The url to join with is determined by the following factors:
+
+* If attempting to load a relative url, such as `{{~ "../foo.png"}}` and using StealJS the template's address will be used as a reference to look up the location.
+* If the `can.baseUrl` string is set, this will be used.
+* If the `System.baseUrl` is set, this will be used.
+* Lastly we fall back to `location.pathname`.

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -165,6 +165,36 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 				}
 			});
 			return options.fn(options.scope, newOptions);
+		},
+		'~': function(firstExpr/* , expr... */){
+			var args = [].slice.call(arguments);
+			var options = args.pop();
+
+			var moduleReference = can.map(args, function(expr){
+				var value = resolve(expr);
+				return can.isFunction(value) ? value() : value;
+			}).join("");
+
+			var templateModule = options.helpers.attr("helpers.module");
+			var parentAddress = templateModule ? templateModule.uri: undefined;
+
+			var isRelative = moduleReference[0] === ".";
+
+			if(isRelative && parentAddress) {
+				return can.joinURIs(parentAddress, moduleReference);
+			} else {
+				var baseUrl = can.baseUrl || (typeof System !== "undefined" &&
+																			System.baseUrl) ||
+																			// TODO support AMD baseurl
+																			location.pathname;
+
+				// Make sure one of them has a needed /
+				if(moduleReference[0] !== "/" && baseUrl[baseUrl.length - 1] !== "/") {
+					baseUrl += "/";
+				}
+
+				return can.joinURIs(baseUrl, moduleReference);
+			}
 		}
 	};
 

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4158,6 +4158,29 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			deepEqual(getText(t.template, t.data), 'Not 10 ducks');
 		});
 
+		test("~ helper joins to the baseUrl", function(){
+			can.baseUrl = "http://foocdn.com/bitovi";
+
+			var template = can.stache("{{~ 'hello/' name}}");
+			var map = new can.Map({ name: "world" });
+
+			var frag = template(map);
+
+			equal(frag.firstChild.nodeValue, "http://foocdn.com/bitovi/hello/world", "joined from can.baseUrl");
+			can.baseUrl = undefined;
+		});
+
+		test("~ helper can be relative to template module", function(){
+			var baseUrl = "http://foocdn.com/bitovi";
+
+			var template = can.stache("{{~ '../hello/' name}}");
+			var map = new can.Map({ name: "world" });
+
+			var frag = template(map, { module: { uri: baseUrl } });
+
+			equal(frag.firstChild.nodeValue, "http://foocdn.com/hello/world", "relative lookup works");
+		});
+
 	}
 
 


### PR DESCRIPTION
The ~ helper is used to create urls (for `<img>` for example) that are
bound to the root of your application or relative to the current module.

If the lookup is relative, such as:

```
{{~ "../hello/world.svg"}}
```

This will lookup the location relative to the current template module
(if using Steal).

Otherwise it will lookup the location through, in descending importance:

* can.baseUrl
* System.baseUrl (if using Steal/System)
* location.pathname

Fixes #1816

Depends on #1821

Includes docs