### PR TITLE
~ helper: use renderingLoader.baseURL

### DIFF
--- a/view/stache/doc/helpers/tilde.md
+++ b/view/stache/doc/helpers/tilde.md
@@ -20,6 +20,6 @@ Where `name` is a scope value, this might return `http://example.com/app/hello/w
 The url to join with is determined by the following factors:
 
 * If attempting to load a relative url, such as `{{~ "../foo.png"}}` and using StealJS the template's address will be used as a reference to look up the location.
-* If the `can.baseUrl` string is set, this will be used.
-* If the `System.baseUrl` is set, this will be used.
+* If the `can.baseURL` string is set, this will be used.
+* If the `System.baseURL` is set, this will be used.
 * Lastly we fall back to `location.pathname`.

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -183,17 +183,17 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			if(isRelative && parentAddress) {
 				return can.joinURIs(parentAddress, moduleReference);
 			} else {
-				var baseUrl = can.baseUrl || (typeof System !== "undefined" &&
-																			System.baseUrl) ||
-																			// TODO support AMD baseurl
+				var baseURL = can.baseURL || (typeof System !== "undefined" &&
+																			(System.renderingLoader && System.renderingLoader.baseURL ||
+																			System.baseURL)) ||
 																			location.pathname;
 
 				// Make sure one of them has a needed /
-				if(moduleReference[0] !== "/" && baseUrl[baseUrl.length - 1] !== "/") {
-					baseUrl += "/";
+				if(moduleReference[0] !== "/" && baseURL[baseURL.length - 1] !== "/") {
+					baseURL += "/";
 				}
 
-				return can.joinURIs(baseUrl, moduleReference);
+				return can.joinURIs(baseURL, moduleReference);
 			}
 		}
 	};

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4158,8 +4158,8 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			deepEqual(getText(t.template, t.data), 'Not 10 ducks');
 		});
 
-		test("~ helper joins to the baseUrl", function(){
-			can.baseUrl = "http://foocdn.com/bitovi";
+		test("~ helper joins to the baseURL", function(){
+			can.baseURL = "http://foocdn.com/bitovi";
 
 			var template = can.stache("{{~ 'hello/' name}}");
 			var map = new can.Map({ name: "world" });


### PR DESCRIPTION
When server-side rendering a separate loader is created that represents
a loader that is actually loading the application in a browser. If the
renderingLoader is present we should use it, and use its baseURL. This
closes out #1816