### PR TITLE
Makes sure unbind is not call unnecessarily on can.Lists passed to can.view.live.list

### DIFF
--- a/view/live/live.js
+++ b/view/live/live.js
@@ -356,12 +356,9 @@ steal('can/util',
 					}
 					
 					
-					// make an empty list if the compute returns null or undefined
-					list = newList || [];
-					
-					
 					afterPreviousEvents = true;
 					if(newList && oldList) {
+						list = newList || [];
 						var patches = diff(oldList, newList);
 						
 						if ( oldList.unbind ) {
@@ -382,6 +379,7 @@ steal('can/util',
 						}
 					} else {
 						teardownList();
+						list = newList || [];
 						add({}, list, 0);
 					}
 					afterPreviousEvents = false;

--- a/view/live/live_test.js
+++ b/view/live/live_test.js
@@ -224,6 +224,32 @@ steal("can/view/live", "can/observe", "can/test", "steal-qunit", function () {
 		
 	});
 	
+	test("can.view.live.list does not unbind on a list unnecessarily (#1835)", function(){
+		expect(0);
+		var div = document.createElement('div'),
+			list = new can.List([
+				'sloth',
+				'bear'
+			]),
+			template = function (animal) {
+				return '<label>Animal=</label> <span>' + animal + '</span>';
+			},
+			unbind = list.unbind;
+			
+		list.unbind = function(){
+			ok(false, "unbind called");
+			return unbind.apply(this, arguments);
+		};
+		
+		div.innerHTML = 'my <b>fav</b> animals: <span></span> !';
+		var el = div.getElementsByTagName('span')[0];
+		
+		can.view.live.list(el, list, template, {});
+		
+		
+		
+	});
+	
 	
 	
 });


### PR DESCRIPTION
fixes  #1835