### PR TITLE
#1837 can-route docs: updated youtube link to an embedded video.

### DIFF
--- a/route/route.md
+++ b/route/route.md
@@ -26,7 +26,7 @@ should start with either a character (a-Z) or colon (:).  Examples:
 
 @body
 
-## Video
+## Use
 
 Watch this video for an overview of can.route's functionality and an example showing how to connect two tab widgets to the browser's history:
 

--- a/route/route.md
+++ b/route/route.md
@@ -9,15 +9,7 @@
 
 @description Manage browser history and
 client state by synchronizing the window.location.hash with
-an [can.Map].
-
-Watch this video for an overview of can.route's functionality and an example showing how to connect two tab widgets to the browser's history:
-
-<iframe width="662" height="372" src="https://www.youtube.com/embed/ef0LKDiaPZ0" frameborder="0" allowfullscreen></iframe>
-
-In the following CanJS community we also talk about web application routing:
-
-<iframe width="662" height="372" src="https://www.youtube.com/watch?v=0Hhuv5Qru9k" frameborder="0" allowfullscreen></iframe>
+a [can.Map].
 
 @signature `can.route( template [, defaults] )`
 
@@ -33,6 +25,16 @@ should start with either a character (a-Z) or colon (:).  Examples:
 @return {can.route}
 
 @body
+
+## Video
+
+Watch this video for an overview of can.route's functionality and an example showing how to connect two tab widgets to the browser's history:
+
+<iframe width="662" height="372" src="https://www.youtube.com/embed/ef0LKDiaPZ0" frameborder="0" allowfullscreen></iframe>
+
+In the following CanJS community we also talk about web application routing:
+
+<iframe width="662" height="372" src="https://www.youtube.com/embed/0Hhuv5Qru9k" frameborder="0" allowfullscreen></iframe>
 
 ## Background Information
 


### PR DESCRIPTION
Updated youtube link to an embedded video which fixes the large empty space.
Moved videos to the body section to keep the description small.