### PR TITLE
Use readOptions to make sure actual values are passed to (event) arguments.

### DIFF
--- a/compute/read.js
+++ b/compute/read.js
@@ -6,7 +6,16 @@ steal("can/util", function(can){
 	// there are things that you need to evaluate when you get them back as a property read
 	// for example a compute or a function you might need to call to get the next value to 
 	// actually check
-	// - isArgument - should be renamed to something like "dontReadLastPropertyValue"
+	// - isArgument - should be renamed to something like "onLastPropertyReadReturnFunctionInsteadOfCallingIt".
+	//   This is used to make a compute out of that function if necessary.
+	// - executeAnonymousFunctions - call a function if it's found
+	// - proxyMethods - if the last read is a method, return a function so `this` will be correct.
+	// - args - arguments to call functions with.
+	// - returnObserveMethods - return the function on an observable instead of trying to call it.
+	//
+	// Callbacks
+	// - earlyExit - called if a value could not be found
+	// - foundObservable - called when an observable value is found
 	var read = function (parent, reads, options) {
 		options = options || {};
 		var state = {

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -222,22 +222,17 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 					notContext: true
 				});
 				var convertToValue = function(arg){
-					if(typeof arg === "function" && arg.isComputed) {
+					if(typeof arg === "function") {
 						return convertToValue( arg() );
 					} else {
 						return arg;
 					}
 				};
 				
-				var args = can.map( attrInfo.args(localScope), convertToValue),
-					hash = {},
-					hasHash;
-				
-				can.each( attrInfo.hash(localScope), function(value, name){
-					hasHash = true;
-					hash[name] = convertToValue(value);
-				});
-				if(hasHash) {
+				var args = attrInfo.args(localScope, null, {}),
+					hash = attrInfo.hash(localScope, null, {});
+					
+				if(!can.isEmptyObject(hash)) {
 					args.push(hash);
 				}
 				/*

--- a/view/bindings/bindings_test.js
+++ b/view/bindings/bindings_test.js
@@ -1324,4 +1324,22 @@ steal("can/view/bindings", "can/map", "can/test", "can/component", "can/view/mus
 		},20);
 		
 	});
+	
+	test("(event) methods on objects are called (#1839)", function(){
+		var template = can.stache("<div (click)='{setSomething person.message}'/>");
+		var data = {
+			setSomething: function(message){
+				equal(message, "Matthew P finds good bugs");
+			},
+			person: {
+				name: "Matthew P",
+				message: function(){
+					return this.name + " finds good bugs";
+				}
+			}
+		};
+		var frag = template(data);
+		can.trigger( frag.firstChild, "click" );
+	});
+	
 });

--- a/view/href/href.js
+++ b/view/href/href.js
@@ -19,21 +19,8 @@ steal("can/util",
 		var attrInfo = mustacheCore.expressionData('tmp ' + removeCurly(el.getAttribute("can-href")));
 		// -> {hash: {foo: 'bar', zed: 5, abc: {get: 'myValue'}}}
 
-		var convertToValue = function(arg){
-			if(typeof arg === "function" && arg.isComputed) {
-				return convertToValue( arg() );
-			} else {
-				return arg;
-			}
-		};
-
 		var routeHref = can.compute(function(){
-			var hash = {};
-			
-			can.each(attrInfo.hash(attrData.scope), function(val, key) {
-				hash[key] = convertToValue(val);
-			});
-			return can.route.url(hash);
+			return can.route.url(attrInfo.hash(attrData.scope, null, {}));
 		});
 
 

--- a/view/stache/mustache_core_test.js
+++ b/view/stache/mustache_core_test.js
@@ -73,12 +73,12 @@ steal("./mustache_core.js", "steal-qunit", function(){
 			{}
 		);
 		
-		var result = callFullName.value(scope, new can.view.Scope({}));
+		var result = callFullName.value(scope, new can.view.Scope({}),  {});
 		
 		equal(result, "marshall thompson");
 	});
 	
-	test("MethodExpression.value non-observable values", function(){
+	test("MethodExpression.value observable values", function(){
 		// {{fullName first 'thompson'}}
 		
 		var scope = new can.view.Scope({
@@ -94,7 +94,7 @@ steal("./mustache_core.js", "steal-qunit", function(){
 			{}
 		);
 		
-		var result = callFullName.value(scope, new can.view.Scope({}));
+		var result = callFullName.value(scope, new can.view.Scope({}), {asCompute: true});
 		
 		equal(result(), "marshall thompson");
 	});


### PR DESCRIPTION
This is a fix for #1839.  This makes the Expression constructs take a `readOptions` argument when evaluating.  You can use `readOptions` to configure the behavior ... if a compute should be returned or a value.