### PR TITLE
Ensure options passed to Stache renderer are mustacheCore.Options

### DIFF
--- a/test/builders/steal-tools/app.html
+++ b/test/builders/steal-tools/app.html
@@ -9,7 +9,7 @@
 	<h1 id="qunit-header">Steal-Tools Build Suite</h1>
 
 	<h2 id="qunit-banner"></h2>
-	
+
 	<div id="qunit-testrunner-toolbar"></div>
 	<h2 id="qunit-userAgent"></h2>
 	<ol id="qunit-tests"></ol>
@@ -20,13 +20,13 @@
 	<script>
 		System.import("config.js").then(function(){
 			System.import("app").then(function(){
-				
+
 				test("stache", function(){
 					var div = document.createElement('div');
 					div.appendChild(MODULE.stache);
-					QUnit.equal( div.getElementsByTagName("h1")[0].innerHTML, "Stache Hi", "matches" );
+					QUnit.equal( div.getElementsByTagName("h1")[0].innerHTML, "Stache HI", "matches" );
 				});
-				
+
 				QUnit.start();
 			});
 		});

--- a/test/builders/steal-tools/app.js
+++ b/test/builders/steal-tools/app.js
@@ -3,8 +3,12 @@ import helloejs from "hello.ejs!ejs";
 import hellomustache from "hello.mustache!mustache";
 import "can/view/autorender/";
 
+function capitalize(txt){
+	return txt.toUpperCase();
+}
+
 window.MODULE = {
 	ejs: helloejs({message: "Hi"}),
 	mustache: hellomustache({message: "Hi"}),
-	stache: helloworld({message: "Hi"})
+	stache: helloworld({message: "Hi"}, { capitalize: capitalize })
 };

--- a/test/builders/steal-tools/helloworld.stache
+++ b/test/builders/steal-tools/helloworld.stache
@@ -1,2 +1,2 @@
 <can-import from="helpers"/>
-<h1>{{templateName}} {{message}}</h1>
+<h1>{{templateName}} {{capitalize message}}</h1>

--- a/test/builders/steal-tools/test.js
+++ b/test/builders/steal-tools/test.js
@@ -61,7 +61,7 @@ describe("Building steal projects", function(){
 							var div = browser.document.createElement('div');
 							div.appendChild(m.stache);
 
-							assert.equal(div.getElementsByTagName('h1')[0].textContent, "Stache Hi", "Stache generated correctly");
+							assert.equal(div.getElementsByTagName('h1')[0].textContent, "Stache HI", "Stache generated correctly");
 							close();
 						}, close);
 					}, done);

--- a/view/stache/system.js
+++ b/view/stache/system.js
@@ -4,6 +4,7 @@ steal("can/view/stache", "can/view/stache/intermediate_and_imports.js",function(
 	function translate(load) {
 		var intermediateAndImports = getIntermediateAndImports(load.source);
 
+		intermediateAndImports.imports.unshift("can/view/stache/mustache_core");
 		intermediateAndImports.imports.unshift("can/view/stache/stache");
 		intermediateAndImports.imports.unshift("module");
 
@@ -15,11 +16,14 @@ steal("can/view/stache", "can/view/stache/intermediate_and_imports.js",function(
 		imports = JSON.stringify(imports);
 		intermediate = JSON.stringify(intermediate);
 
-		return "define("+imports+",function(module, stache){\n" +
+		return "define("+imports+",function(module, stache, mustacheCore){\n" +
 			"\tvar renderer = stache(" + intermediate + ");\n" +
 			"\treturn function(scope, options){\n" +
 			"\t\tvar moduleOptions = { module: module };\n" +
-			"\t\treturn renderer(scope, options ? options.add(moduleOptions) : moduleOptions);\n" +
+			"\t\tif(!(options instanceof mustacheCore.Options)) {\n" +
+			"\t\t\toptions = new mustacheCore.Options(options || {});\n" +
+			"\t\t}\n" +
+			"\t\treturn renderer(scope, options.add(moduleOptions));\n" +
 			"\t};\n" +
 		"});";
 	}


### PR DESCRIPTION
This is a fix for #1843. Was assuming that if options were passed they
were mustacheCore.Options but a plain object can be passed as well. The
fix is to make sure the options are mustacheCore.Options and then add
moduleOptions to that.