### PR TITLE
System Stache plugin: Add dynamic imports to bundle

### DIFF
--- a/build/config_stealPluginify.js
+++ b/build/config_stealPluginify.js
@@ -211,6 +211,10 @@ module.exports = function(){
 					graphs: allModuleNames.concat(['can']),
 					useNormalizedDependencies: false,
 					normalize: function(depName, depLoad, curName, curLoad ){
+						// @loader is part of the
+						if(!depLoad) {
+							return depName;
+						}
 
 						// if its not in node_modules
 						if(depLoad.address.indexOf("node_modules") === -1 && curLoad.address.indexOf("node_modules") === -1) {

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
 		"jquerypp": "^2.0.0",
 		"lodash": "2.4.1",
 		"rimraf": "2.1",
-		"steal": "^0.10.1",
+		"steal": "^0.11.0-pre.2",
 		"steal-benchmark": "~0.0.1",
 		"steal-qunit": "0.0.2",
-		"steal-tools": "^0.10.0",
+		"steal-tools": "^0.11.0-pre.8",
 		"testee": "^0.1.3",
-		"zombie": "~2.0.8",
+		"zombie": "2.5.1",
 		"documentjs": "0.3.0-pre.5"
 	},
 	"scripts": {

--- a/test/builders/steal-tools/bundle/config.js
+++ b/test/builders/steal-tools/bundle/config.js
@@ -36,11 +36,6 @@
 			"jquery": "../../../../node_modules/jquery/dist/jquery.js",
 			"can/*": "../../../../*.js"
 		},
-		meta: {
-			jquery: {
-				exports: "jQuery"
-			}
-		},
 		ext: {
 			ejs: "can/view/ejs/system",
 			mustache: "can/view/mustache/system",

--- a/test/builders/steal-tools/config.js
+++ b/test/builders/steal-tools/config.js
@@ -36,11 +36,6 @@
 			"jquery": "../../../node_modules/jquery/dist/jquery.js",
 			"can/*": "../../../*.js"
 		},
-		meta: {
-			jquery: {
-				exports: "jQuery"
-			}
-		},
 		ext: {
 			ejs: "view/ejs/ejs.js",
 			mustache: "view/mustache/mustache.js",

--- a/test/builders/steal-tools/import/app.js
+++ b/test/builders/steal-tools/import/app.js
@@ -1,0 +1,1 @@
+var tmpl = require("./app.stache!stache");

--- a/test/builders/steal-tools/import/app.stache
+++ b/test/builders/steal-tools/import/app.stache
@@ -1,0 +1,7 @@
+<can-import from="import/other" />
+
+{{#eq page "list"}}
+	<can-import from="import/thing">
+		<span>thing</span>
+	</can-import>
+{{/if}}

--- a/test/builders/steal-tools/import/other.js
+++ b/test/builders/steal-tools/import/other.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/builders/steal-tools/import/thing.js
+++ b/test/builders/steal-tools/import/thing.js
@@ -1,0 +1,1 @@
+module.exports = "thing";

--- a/test/pluginified/2.0.5.test.js
+++ b/test/pluginified/2.0.5.test.js
@@ -1,4 +1,4 @@
-(function(undefined) {
+(function(module, undefined) {
 
 // ## component/component_test.js
 var __m1 = (function () {
@@ -14194,4 +14194,4 @@ var __m79 = (function () {
 })(undefined);
 
 
-})();
+})(QUnit.module);

--- a/view/stache/intermediate_and_imports.js
+++ b/view/stache/intermediate_and_imports.js
@@ -5,15 +5,18 @@ steal("can/view/stache/mustache_core.js", "can/view/parser",
 
 		var template = mustacheCore.cleanLineEndings(source);
 		var imports = [],
+			dynamicImports = [],
 			ases = {},
 			inImport = false,
 			inFrom = false,
 			inAs = false,
+			isUnary = false,
 			currentAs = "",
 			currentFrom = "";
 
 		var intermediate = parser(template, {
 			start: function( tagName, unary ){
+				isUnary = unary;
 				if(tagName === "can-import") {
 					inImport = true;
 				} else if(inImport) {
@@ -37,6 +40,9 @@ steal("can/view/stache/mustache_core.js", "can/view/parser",
 			attrValue: function( value ){
 				if(inFrom && inImport) {
 					imports.push(value);
+					if(!isUnary) {
+						dynamicImports.push(value);
+					}
 					currentFrom = value;
 				} else if(inAs && inImport) {
 					currentAs = value;
@@ -58,7 +64,12 @@ steal("can/view/stache/mustache_core.js", "can/view/parser",
 			}
 		}, true);
 
-		return {intermediate: intermediate, imports: imports, ases: ases};
+		return {
+			intermediate: intermediate,
+			imports: imports,
+			dynamicImports: dynamicImports,
+			ases: ases
+		};
 	};
 
 });

--- a/view/stache/system.js
+++ b/view/stache/system.js
@@ -1,8 +1,26 @@
 "format steal";
-steal("can/view/stache", "can/view/stache/intermediate_and_imports.js",function(stache, getIntermediateAndImports){
+steal("@loader", "can/util/can.js", "can/view/stache", "can/view/stache/intermediate_and_imports.js",function(loader, can, stache, getIntermediateAndImports){
+
+	function addBundles(dynamicImports) {
+		if(!dynamicImports.length) return;
+
+		var bundle = loader.localLoader.bundle;
+		if(!bundle) {
+			bundle = loader.localLoader.bundle = [];
+		}
+
+		can.each(dynamicImports, function(moduleName){
+			if(!~bundle.indexOf(moduleName)) {
+				bundle.push(moduleName);
+			}
+		});
+	}
 
 	function translate(load) {
 		var intermediateAndImports = getIntermediateAndImports(load.source);
+
+		// Add bundle configuration for these dynamic imports
+		addBundles(intermediateAndImports.dynamicImports);
 
 		intermediateAndImports.imports.unshift("can/view/stache/mustache_core");
 		intermediateAndImports.imports.unshift("can/view/stache/stache");

--- a/view/stache/system.js
+++ b/view/stache/system.js
@@ -2,7 +2,9 @@
 steal("@loader", "can/util/can.js", "can/view/stache", "can/view/stache/intermediate_and_imports.js",function(loader, can, stache, getIntermediateAndImports){
 
 	function addBundles(dynamicImports) {
-		if(!dynamicImports.length) return;
+		if(!dynamicImports.length) {
+			return;
+		}
 
 		var bundle = loader.localLoader.bundle;
 		if(!bundle) {


### PR DESCRIPTION
This updates the Stache plugin to add dynamic `<can-import>` statements
to the System.bundle configuration, thus making this step unnecessary
for users if using can-import for dynamic loading.