### PR TITLE
Regression, dynamically imported can-imports caused an exception

### DIFF
--- a/view/import/import_test.js
+++ b/view/import/import_test.js
@@ -113,4 +113,20 @@ steal('can/view/stache/', 'can/component/', 'can/view/stache/intermediate_and_im
 			});
 		});
 
+		asyncTest("can dynamically import a template and use it", function(){
+			var template = "<can-import from='can/view/import/test/other-dynamic.stache!' #other='{value}'/>{{> other}}";
+
+			can.stache.async(template).then(function(renderer){
+				var frag = renderer();
+
+				// Import will happen async
+				can["import"]("can/view/import/test/other.stache!").then(function(){
+					equal(frag.childNodes[3].firstChild.nodeValue, "hi there", "Partial was renderered right after the can-import");
+
+					QUnit.start();
+				});
+			});
+
+		});
+
 	});

--- a/view/import/test/other-dynamic.stache
+++ b/view/import/test/other-dynamic.stache
@@ -1,0 +1,5 @@
+<can-import from="./thing">
+
+</can-import>
+
+<span>hi there</span>

--- a/view/stache/system.js
+++ b/view/stache/system.js
@@ -6,9 +6,11 @@ steal("@loader", "can/util/can.js", "can/view/stache", "can/view/stache/intermed
 			return;
 		}
 
-		var bundle = loader.localLoader.bundle;
+		// In the build the "main" loader is the localLoader
+		var localLoader = loader.localLoader || loader;
+		var bundle = localLoader.bundle;
 		if(!bundle) {
-			bundle = loader.localLoader.bundle = [];
+			bundle = localLoader.bundle = [];
 		}
 
 		can.each(dynamicImports, function(moduleName){


### PR DESCRIPTION
This is a regression caused by #1845. Were assuming a loader.localLoader
exists, but this is a loader that only exists during the build. There
wasn't a test that caught this, so I added a test in import_test.js that
dynamically imports a module. This failed before the fix.