### PR TITLE
Update system-config to reflect the current Steal env

### DIFF
--- a/system-config.js
+++ b/system-config.js
@@ -1,8 +1,9 @@
 "format cjs";
 
 var MySystem = require('@loader');
+var isDevelopment = MySystem.env === "development" || (MySystem.envMap && MySystem.envMap.development);
 
-if(MySystem.env === "development" && typeof window === "undefined" && !MySystem.buildForClient) {
+if(isDevelopment && typeof window === "undefined" && !MySystem.buildForClient) {
 	exports.systemConfig = {
 		meta: {
 			'jquery': {


### PR DESCRIPTION
Steal's System.env can now have multiple values such as:

```
System.env = "production,server";
```

This would apply on the server. This makes the `envs` config work. So
now there is a System.envMap which will be something like `{
server: true, production: true}`. So this change updates out
system-config to use that map.