### PR TITLE
Test against new steal-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"steal": "^0.11.0-pre.0",
 		"steal-benchmark": "~0.0.1",
 		"steal-qunit": "0.0.2",
-		"steal-tools": "^0.11.0-pre.8",
+		"steal-tools": "^0.11.0-pre.12",
 		"testee": "^0.1.3",
 		"zombie": "2.5.1",
 		"documentjs": "0.3.0-pre.5"


### PR DESCRIPTION
The 0.11.0-pre.11 prerelease of steal-tools broke the built. I'm testing
against a possible fix to confirm it. Do not merge.