### PR TITLE
Makes list.slice observable by computes

### DIFF
--- a/list/list.js
+++ b/list/list.js
@@ -624,7 +624,7 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 		 * ```
 		 */
 		indexOf: function (item, fromIndex) {
-			this.attr('length');
+			can.__observe(this, "length");
 			return can.inArray(item, this, fromIndex);
 		},
 
@@ -650,7 +650,8 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 		 * ```
 		 */
 		join: function () {
-			return [].join.apply(this.attr(), arguments);
+			can.__observe(this, "length");
+			return [].join.apply(this, arguments);
 		},
 
 		/**
@@ -708,6 +709,8 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 		 * ```
 		 */
 		slice: function () {
+			// tells computes to listen on length for changes.
+			can.__observe(this, "length");
 			var temp = Array.prototype.slice.apply(this, arguments);
 			return new this.constructor(temp);
 		},

--- a/list/list_test.js
+++ b/list/list_test.js
@@ -315,4 +315,30 @@ steal("can/util", "can/list", "can/test", "can/compute", "steal-qunit", function
 		var children = new ChildList([1,2,3]);
 		ok(children.reverse() === children);
 	});
+	
+	
+	test("slice and join are observable by a compute (#1884)", function(){
+		expect(2);
+		
+		var list = new can.List([1,2,3]);
+		
+		var sliced = can.compute(function(){
+			return list.slice(0,1);
+		});
+		var joined = can.compute(function(){
+			return list.join(",");
+		});
+		
+		sliced.bind("change", function(ev, newVal){
+			deepEqual(newVal.attr(), [2], "got a new can.List");
+		});
+		joined.bind("change", function(ev, newVal){
+			equal(newVal, "2,3", "joined is observable");
+		});
+		
+		list.shift();
+		
+		
+	});
+	
 });


### PR DESCRIPTION
fixes #1884


Adds `can.__observe(list, "length")` so computes listen to when items are added or removed.