### PR TITLE
fixed regression component control destructor

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -467,6 +467,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 			this._bindings.readyComputes = {};
 		},
 		destroy: function() {
+			can.Control.prototype.destroy.apply( this, arguments );
 			if(typeof this.options.destroy === 'function') {
 				this.options.destroy.apply(this, arguments);
 			}

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1681,19 +1681,19 @@ steal("can", "can/map/define", "can/component", "can/view/stache" ,"can/route", 
 		});
 
 		test("components control destroy method is called", function(){
-		expect(0);
-		can.Component.extend({
-			tag: 'comp-control-destroy-test',
-			template: can.stache('<div>click me</div>'),
-			events: {
-				"{document} click" : function () {
-					ok(true, "click registered");
+			expect(0);
+			can.Component.extend({
+				tag: 'comp-control-destroy-test',
+				template: can.stache('<div>click me</div>'),
+				events: {
+					"{document} click" : function () {
+						ok(true, "click registered");
+					}
 				}
-			}
+			});
+			can.append(can.$("#qunit-fixture"), can.stache("<comp-control-destroy-test></comp-control-destroy-test>")({}));
+			can.remove(can.$("#qunit-fixture>*"));
+			can.trigger(can.$(document), 'click');
 		});
-		can.append(can.$("#qunit-fixture"), can.stache("<comp-control-destroy-test></comp-control-destroy-test>")({}));
-		can.remove(can.$("#qunit-fixture>*"));
-		can.trigger(can.$(document), 'click');
-	});
 	}
 });

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1679,5 +1679,21 @@ steal("can", "can/map/define", "can/component", "can/view/stache" ,"can/route", 
 				start();
 			}, 20);
 		});
+
+		test("components control destroy method is called", function(){
+		expect(0);
+		can.Component.extend({
+			tag: 'comp-control-destroy-test',
+			template: can.stache('<div>click me</div>'),
+			events: {
+				"{document} click" : function () {
+					ok(true, "click registered");
+				}
+			}
+		});
+		can.append(can.$("#qunit-fixture"), can.stache("<comp-control-destroy-test></comp-control-destroy-test>")({}));
+		can.remove(can.$("#qunit-fixture>*"));
+		can.trigger(can.$(document), 'click');
+	});
 	}
 });


### PR DESCRIPTION
This fixes a regression introduced in #1803 where the component's
control destroy method isn't called anymore when the component is
removed from the DOM.