### PR TITLE
#1837 docs: moved videos to the body section (can.Map and can.Conponent)

### DIFF
--- a/component/component.md
+++ b/component/component.md
@@ -9,16 +9,6 @@
 @description Create widgets that use a template, a view-model 
 and custom tags.
 
-Watch this video for an overview of can.Component, why you should use it, and a hello world example:
-
-<iframe width="662" height="372" src="https://www.youtube.com/embed/BM1Jc3lVUrk" frameborder="0" allowfullscreen></iframe>
-
-This video provides a more in depth overview of the API and goes over several examples of can.Components:
-
-<iframe width="662" height="372" src="https://www.youtube.com/embed/ogX765S4iuc" frameborder="0" allowfullscreen></iframe>
-
-Note: the videos above reference the `scope` property, which was replaced by the [can.Component::viewModel viewModel] property in 2.2.
-
 @signature `< TAG [ATTR-NAME="{KEY}|ATTR-VALUE"] >`
 
 Create an instance of a component on a particular 
@@ -75,6 +65,16 @@ up in the [can.view.Scope can.stache scope].
 @body
 
 ## Use
+
+Watch this video for an overview of can.Component, why you should use it, and a hello world example:
+
+<iframe width="662" height="372" src="https://www.youtube.com/embed/BM1Jc3lVUrk" frameborder="0" allowfullscreen></iframe>
+
+This video provides a more in depth overview of the API and goes over several examples of can.Components:
+
+<iframe width="662" height="372" src="https://www.youtube.com/embed/ogX765S4iuc" frameborder="0" allowfullscreen></iframe>
+
+Note: the videos above reference the `scope` property, which was replaced by the [can.Component::viewModel viewModel] property in 2.2.
 
 To create a `can.Component`, you must first [can.Component.extend extend] `can.Component`
 with the methods and properties of how your component behaves:

--- a/map/doc/map.md
+++ b/map/doc/map.md
@@ -12,10 +12,6 @@
 @description Create observable objects.
 
 
-Watch this video to see an example of creating an ATM machine using can.Map:
-
-<iframe width="662" height="372" src="https://www.youtube.com/embed/QP9mHyxZNiI" frameborder="0" allowfullscreen></iframe>
-
 @signature `new can.Map([props])`
 
 Creates a new instance of can.Map.
@@ -29,6 +25,13 @@ Creates a new extended constructor function.
 
 
 @body
+
+## Use
+
+Watch this video to see an example of creating an ATM machine using can.Map:
+
+<iframe width="662" height="372" src="https://www.youtube.com/embed/QP9mHyxZNiI" frameborder="0" allowfullscreen></iframe>
+
 
 `can.Map` provides a way for you to listen for and keep track of changes
 to objects. When you use the getters and setters provided by `can.Map`,


### PR DESCRIPTION
This is similar to can-route docs: videos moved to the body section under "Use" header.