### PR TITLE
Fix issue with #unless helper and computes - #1202

### DIFF
--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -9,9 +9,9 @@ steal('can/util',
 
 		// # mustache.js
 		// `can.Mustache`: The Mustache templating engine.
-		// 
-		// See the [Transformation](#section-29) section within *Scanning Helpers* for a detailed explanation 
-		// of the runtime render code design. The majority of the Mustache engine implementation 
+		//
+		// See the [Transformation](#section-29) section within *Scanning Helpers* for a detailed explanation
+		// of the runtime render code design. The majority of the Mustache engine implementation
 		// occurs within the *Transformation* scanning helper.
 
 		// ## Initialization
@@ -119,7 +119,7 @@ steal('can/util',
 		// Put Mustache on the `can` object.
 		can.Mustache = can.global.Mustache = Mustache;
 
-		/** 
+		/**
 		 * @prototype
 		 */
 		Mustache.prototype.
@@ -155,7 +155,7 @@ steal('can/util',
 			scanner: new can.view.Scanner({
 				// A hash of strings for the scanner to inject at certain points.
 				text: {
-					// This is the logic to inject at the beginning of a rendered template. 
+					// This is the logic to inject at the beginning of a rendered template.
 					// This includes initializing the `context` stack.
 					start: "", //"var "+SCOPE+"= this instanceof can.view.Scope? this : new can.view.Scope(this);\n",
 					scope: SCOPE,
@@ -174,14 +174,14 @@ steal('can/util',
 				//			// A simple token to match, like "{{".
 				//			"token",
 				//
-				//			// Optional. A complex (regexp) token to match that 
+				//			// Optional. A complex (regexp) token to match that
 				//			// overrides the simple token.
 				//			"[\\s\\t]*{{",
 				//
-				//			// Optional. A function that executes advanced 
-				//			// manipulation of the matched content. This is 
+				//			// Optional. A function that executes advanced
+				//			// manipulation of the matched content. This is
 				//			// rarely used.
-				//			function(content){   
+				//			function(content){
 				//				return content;
 				//			}
 				//		]
@@ -379,7 +379,7 @@ steal('can/util',
 				//			//                             status: 0
 				//			//                           }
 				//			fn: function(content, cmd) {
-				//				return 'for text injection' || 
+				//				return 'for text injection' ||
 				//					{ raw: 'to bypass text injection' };
 				//			}
 				//		}
@@ -387,18 +387,18 @@ steal('can/util',
 					// ### Partials
 					//
 					// Partials begin with a greater than sign, like {{> box}}.
-					// 
-					// Partials are rendered at runtime (as opposed to compile time), 
+					//
+					// Partials are rendered at runtime (as opposed to compile time),
 					// so recursive partials are possible. Just avoid infinite loops.
-					// 
+					//
 					// For example, this template and partial:
-					// 
+					//
 					// 		base.mustache:
 					// 			<h2>Names</h2>
 					// 			{{#names}}
 					// 				{{> user}}
 					// 			{{/names}}
-					// 			
+					//
 					// 		user.mustache:
 					// 			<strong>{{name}}</strong>
 					{
@@ -413,17 +413,17 @@ steal('can/util',
 					},
 
 					// ### Data Hookup
-					// 
+					//
 					// This will attach the data property of `this` to the element
 					// its found on using the first argument as the data attribute
 					// key.
-					// 
+					//
 					// For example:
-					// 	
+					//
 					//		<li id="nameli" {{ data 'name' }}></li>
-					// 
+					//
 					// then later you can access it like:
-					// 
+					//
 					//		can.$('#nameli').data('name');
 					/**
 					 * @function can.mustache.helpers.data {{data name}}
@@ -478,34 +478,34 @@ steal('can/util',
 							var quickFunc = /\s*\(([\$\w]+)\)\s*->([^\n]*)/,
 								parts = content.match(quickFunc);
 
-							//find 
+							//find
 							return "can.proxy(function(__){var " + parts[1] + "=can.$(__);with(" + SCOPE + ".attr('.')){" + parts[2] + "}}, this);";
 						}
 					},
 					// ### Transformation (default)
 					//
 					// This transforms all content to its interpolated equivalent,
-					// including calls to the corresponding helpers as applicable. 
+					// including calls to the corresponding helpers as applicable.
 					// This outputs the render code for almost all cases.
 					//
 					// #### Definitions
-					// 
-					// * `context` - This is the object that the current rendering context operates within. 
+					//
+					// * `context` - This is the object that the current rendering context operates within.
 					//		Each nested template adds a new `context` to the context stack.
-					// * `stack` - Mustache supports nested sections, 
+					// * `stack` - Mustache supports nested sections,
 					//		each of which add their own context to a stack of contexts.
-					//		Whenever a token gets interpolated, it will check for a match against the 
+					//		Whenever a token gets interpolated, it will check for a match against the
 					//		last context in the stack, then iterate through the rest of the stack checking for matches.
 					//		The first match is the one that gets returned.
 					// * `Mustache.txt` - This serializes a collection of logic, optionally contained within a section.
 					//		If this is a simple interpolation, only the interpolation lookup will be passed.
-					//		If this is a section, then an `options` object populated by the truthy (`options.fn`) and 
-					//		falsey (`options.inverse`) encapsulated functions will also be passed. This section handling 
+					//		If this is a section, then an `options` object populated by the truthy (`options.fn`) and
+					//		falsey (`options.inverse`) encapsulated functions will also be passed. This section handling
 					//		exists to support the runtime context nesting that Mustache supports.
 					// * `Mustache.get` - This resolves an interpolation reference given a stack of contexts.
-					// * `options` - An object containing methods for executing the inner contents of sections or helpers.  
-					//		`options.fn` - Contains the inner template logic for a truthy section.  
-					//		`options.inverse` - Contains the inner template logic for a falsey section.  
+					// * `options` - An object containing methods for executing the inner contents of sections or helpers.
+					//		`options.fn` - Contains the inner template logic for a truthy section.
+					//		`options.inverse` - Contains the inner template logic for a falsey section.
 					//		`options.hash` - Contains the merged hash object argument for custom helpers.
 					//
 					// #### Design
@@ -513,17 +513,17 @@ steal('can/util',
 					// This covers the design of the render code that the transformation helper generates.
 					//
 					// ##### Pseudocode
-					// 
+					//
 					// A detailed explanation is provided in the following sections, but here is some brief pseudocode
-					// that gives a high level overview of what the generated render code does (with a template similar to  
+					// that gives a high level overview of what the generated render code does (with a template similar to
 					// `"{{#a}}{{b.c.d.e.name}}{{/a}}" == "Phil"`).
 					//
 					// *Initialize the render code.*
-					// 
+					//
 					// 		view = []
 					// 		context = []
 					// 		stack = fn { context.concat([this]) }
-					// 		
+					//
 					// *Render the root section.*
 					//
 					// 		view.push( "string" )
@@ -531,22 +531,22 @@ steal('can/util',
 					//
 					// *Render the nested section with `can.Mustache.txt`.*
 					//
-					// 			txt( 
+					// 			txt(
 					//
 					// *Add the current context to the stack.*
 					//
-					// 				stack(), 
+					// 				stack(),
 					//
 					// *Flag this for truthy section mode.*
 					//
 					// 				"#",
 					//
 					// *Interpolate and check the `a` variable for truthyness using the stack with `can.Mustache.get`.*
-					// 
+					//
 					// 				get( "a", stack() ),
 					//
 					// *Include the nested section's inner logic.
-					// The stack argument is usually the parent section's copy of the stack, 
+					// The stack argument is usually the parent section's copy of the stack,
 					// but it can be an override context that was passed by a custom helper.
 					// Sections can nest `0..n` times -- **NESTCEPTION**.*
 					//
@@ -596,8 +596,8 @@ steal('can/util',
 					// 			if (arguments.length == 1 && context) {
 					// 				s = !context.__sc0pe ? [context] : context;
 					// 			} else {
-					// 				s = context && context.__sc0pe 
-					//					? context.concat([self]) 
+					// 				s = context && context.__sc0pe
+					//					? context.concat([self])
 					//					: __sc0pe(context).concat([self]);
 					// 			}
 					// 			return (s.__sc0pe = true) && s;
@@ -606,54 +606,54 @@ steal('can/util',
 					// The `___v1ew` is the the array used to serialize the view.
 					// The `___c0nt3xt` is a stacking array of contexts that slices and expands with each nested section.
 					// The `__sc0pe` function is used to more easily update the context stack in certain situations.
-					// Usually, the stack function simply adds a new context (`self`/`this`) to a context stack. 
+					// Usually, the stack function simply adds a new context (`self`/`this`) to a context stack.
 					// However, custom helpers will occasionally pass override contexts that need their own context stack.
 					//
 					// ##### Sections
 					//
-					// Each section, `{{#section}} content {{/section}}`, within a Mustache template generates a section 
-					// context in the resulting render code. The template itself is treated like a root section, with the 
+					// Each section, `{{#section}} content {{/section}}`, within a Mustache template generates a section
+					// context in the resulting render code. The template itself is treated like a root section, with the
 					// same execution logic as any others. Each section can have `0..n` nested sections within it.
 					//
-					// Here's an example of a template without any descendent sections.  
-					// Given the template: `"{{a.b.c.d.e.name}}" == "Phil"`  
+					// Here's an example of a template without any descendent sections.
+					// Given the template: `"{{a.b.c.d.e.name}}" == "Phil"`
 					// Would output the following render code:
 					//
 					//		___v1ew.push("\"");
 					//		___v1ew.push(can.view.txt(1, '', 0, this, function() {
-					// 			return can.Mustache.txt(__sc0pe(___c0nt3xt, this), null, 
-					//				can.Mustache.get("a.b.c.d.e.name", 
+					// 			return can.Mustache.txt(__sc0pe(___c0nt3xt, this), null,
+					//				can.Mustache.get("a.b.c.d.e.name",
 					//					__sc0pe(___c0nt3xt, this))
 					//			);
 					//		}));
 					//		___v1ew.push("\" == \"Phil\"");
 					//
-					// The simple strings will get appended to the view. Any interpolated references (like `{{a.b.c.d.e.name}}`) 
+					// The simple strings will get appended to the view. Any interpolated references (like `{{a.b.c.d.e.name}}`)
 					// will be pushed onto the view via `can.view.txt` in order to support live binding.
-					// The function passed to `can.view.txt` will call `can.Mustache.txt`, which serializes the object data by doing 
+					// The function passed to `can.view.txt` will call `can.Mustache.txt`, which serializes the object data by doing
 					// a context lookup with `can.Mustache.get`.
 					//
 					// `can.Mustache.txt`'s first argument is a copy of the context stack with the local context `this` added to it.
 					// This stack will grow larger as sections nest.
 					//
-					// The second argument is for the section type. This will be `"#"` for truthy sections, `"^"` for falsey, 
+					// The second argument is for the section type. This will be `"#"` for truthy sections, `"^"` for falsey,
 					// or `null` if it is an interpolation instead of a section.
 					//
-					// The third argument is the interpolated value retrieved with `can.Mustache.get`, which will perform the 
+					// The third argument is the interpolated value retrieved with `can.Mustache.get`, which will perform the
 					// context lookup and return the approriate string or object.
 					//
 					// Any additional arguments, if they exist, are used for passing arguments to custom helpers.
 					//
 					// For nested sections, the last argument is an `options` object that contains the nested section's logic.
 					//
-					// Here's an example of a template with a single nested section.  
-					// Given the template: `"{{#a}}{{b.c.d.e.name}}{{/a}}" == "Phil"`  
+					// Here's an example of a template with a single nested section.
+					// Given the template: `"{{#a}}{{b.c.d.e.name}}{{/a}}" == "Phil"`
 					// Would output the following render code:
 					//
 					//		___v1ew.push("\"");
 					// 		___v1ew.push(can.view.txt(0, '', 0, this, function() {
-					// 			return can.Mustache.txt(__sc0pe(___c0nt3xt, this), "#", 
-					//				can.Mustache.get("a", __sc0pe(___c0nt3xt, this)), 
+					// 			return can.Mustache.txt(__sc0pe(___c0nt3xt, this), "#",
+					//				can.Mustache.get("a", __sc0pe(___c0nt3xt, this)),
 					//					[{
 					// 					_: function() {
 					// 						return ___v1ew.join("");
@@ -661,12 +661,12 @@ steal('can/util',
 					// 				}, {
 					// 					fn: function(___c0nt3xt) {
 					// 						var ___v1ew = [];
-					// 						___v1ew.push(can.view.txt(1, '', 0, this, 
+					// 						___v1ew.push(can.view.txt(1, '', 0, this,
 					//								function() {
 					//                                  return can.Mustache.txt(
-					// 									__sc0pe(___c0nt3xt, this), 
-					// 									null, 
-					// 									can.Mustache.get("b.c.d.e.name", 
+					// 									__sc0pe(___c0nt3xt, this),
+					// 									null,
+					// 									can.Mustache.get("b.c.d.e.name",
 					// 										__sc0pe(___c0nt3xt, this))
 					// 								);
 					// 							}
@@ -682,11 +682,11 @@ steal('can/util',
 					// These act similarly to custom helpers: `options.fn` will be called for truthy sections, `options.inverse` will be called for falsey sections.
 					// The `options._` function only exists as a dummy function to make generating the section nesting easier (a section may have a `fn`, `inverse`,
 					// or both, but there isn't any way to determine that at compilation time).
-					// 
+					//
 					// Within the `fn` function is the section's render context, which in this case will render anything between the `{{#a}}` and `{{/a}}` tokens.
 					// This function has `___c0nt3xt` as an argument because custom helpers can pass their own override contexts. For any case where custom helpers
 					// aren't used, `___c0nt3xt` will be equivalent to the `__sc0pe(___c0nt3xt, this)` stack created by its parent section. The `inverse` function
-					// works similarly, except that it is added when `{{^a}}` and `{{else}}` are used. `var ___v1ew = []` is specified in `fn` and `inverse` to 
+					// works similarly, except that it is added when `{{^a}}` and `{{else}}` are used. `var ___v1ew = []` is specified in `fn` and `inverse` to
 					// ensure that live binding in nested sections works properly.
 					//
 					// All of these nested sections will combine to return a compiled string that functions similar to EJS in its uses of `can.view.txt`.
@@ -707,7 +707,7 @@ steal('can/util',
 							content = can.trim(content);
 
 							// Determine what the active mode is.
-							// 
+							//
 							// * `#` - Truthy section
 							// * `^` - Falsey section
 							// * `/` - Close the prior section
@@ -812,7 +812,7 @@ steal('can/util',
 									 *
 									 *     Hi Jon!
 									 */
-									// 
+									//
 									/**
 									 * @function can.mustache.helpers.helper {{helper args hashes}}
 									 * @parent can.mustache.htags 0
@@ -977,7 +977,7 @@ steal('can/util',
 									 * on the [can.mustache.helper helper function] page.
 									 *
 									 */
-									// 
+									//
 									/**
 									 * @function can.mustache.helpers.sectionHelper {{#helper args hashes}}
 									 * @parent can.mustache.htags 1
@@ -1209,7 +1209,7 @@ steal('can/util',
 								content = content.substring(1);
 							}
 
-							// `else` helpers are special and should be skipped since they don't 
+							// `else` helpers are special and should be skipped since they don't
 							// have any logic aside from kicking off an `inverse` function.
 							if (mode !== 'else') {
 								var args = [],
@@ -1223,7 +1223,7 @@ steal('can/util',
 									',\n' + (mode ? '"' + mode + '"' : 'null') + ',';
 
 								// Parse the helper arguments.
-								// This needs uses this method instead of a split(/\s/) so that 
+								// This needs uses this method instead of a split(/\s/) so that
 								// strings with spaces can be correctly parsed.
 								(can.trim(content) + ' ')
 									.replace(argumentsRegExp, function (whole, arg) {
@@ -1548,7 +1548,7 @@ steal('can/util',
 			// computeData gives us an initial value
 			var initialValue = computeData.initialValue,
 				helperObj = Mustache.getHelper(key, options);
-			  
+
 			//!steal-remove-start
 			if (initialValue === undefined && !isHelper && !helperObj) {
 				can.dev.warn('can/view/mustache/mustache.js: Unable to find key "' + key + '".');
@@ -1609,13 +1609,13 @@ steal('can/util',
 		//
 		// Custom helpers can be added via `can.Mustache.registerHelper`,
 		// but there are also some built-in helpers included by default.
-		// Most of the built-in helpers are little more than aliases to actions 
-		// that the base version of Mustache simply implies based on the 
+		// Most of the built-in helpers are little more than aliases to actions
+		// that the base version of Mustache simply implies based on the
 		// passed in object.
-		// 
+		//
 		// Built-in helpers:
-		// 
-		// * `data` - `data` is a special helper that is implemented via scanning helpers. 
+		//
+		// * `data` - `data` is a special helper that is implemented via scanning helpers.
 		//		It hooks up the active element to the active data object: `<div {{data "key"}} />`
 		// * `if` - Renders a truthy section: `{{#if var}} render {{/if}}`
 		// * `unless` - Renders a falsey section: `{{#unless var}} render {{/unless}}`
@@ -1692,7 +1692,7 @@ steal('can/util',
 		Mustache.render = function (partial, scope, options) {
 			// TOOD: clean up the following
 			// If there is a "partial" property and there is not
-			// an already-cached partial, we use the value of the 
+			// an already-cached partial, we use the value of the
 			// property to look up the partial
 
 			// if this partial is not cached ...
@@ -1714,7 +1714,7 @@ steal('can/util',
 		/**
 		 * @function can.mustache.safeString
 		 * @parent can.mustache.methods
-		 * 
+		 *
 		 * @signature `can.mustache.safeString(str)`
 		 *
 		 * @param {String} str A string you don't want to become escaped.
@@ -1924,7 +1924,10 @@ steal('can/util',
 			 *     {{/unless}}
 			 */
 			'unless': function (expr, options) {
-				return Mustache._helpers['if'].fn.apply(this, [can.isFunction(expr) ? can.compute(function() { return !expr(); }) : !expr, options]);
+				return Mustache._helpers['if'].fn.apply(this, [expr, can.extend({}, options, {
+					fn: options.inverse,
+					inverse: options.fn
+				})]);
 			},
 
 			// Implements the `each` built-in helper.
@@ -2004,7 +2007,7 @@ steal('can/util',
 			 */
 			'each': function (expr, options) {
 				// Check if this is a list or a compute that resolves to a list, and setup
-				// the incremental live-binding 
+				// the incremental live-binding
 
 				// First, see what we are dealing with.  It's ok to read the compute
 				// because can.view.text is only temporarily binding to what is going on here.
@@ -2246,7 +2249,7 @@ steal('can/util',
 				});
 			}
 		});
-		
+
 		can.mustache.registerHelper = can.proxy(can.Mustache.registerHelper, can.Mustache);
 		can.mustache.safeString = can.Mustache.safeString;
 		return can;

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -571,7 +571,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 	test("Handlebars helper: unless", function () {
 		var t = {
 			template: "{{#unless missing}}Andy is missing!{{/unless}}" +
-					  "{{#unless isCool}} But he wasn't cool anyways.{{/unless}}",
+			          "{{#unless isCool}} But he wasn't cool anyways.{{/unless}}",
 			expected: "Andy is missing! But he wasn't cool anyways.",
 			data: {
 				name: 'Andy'

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -86,7 +86,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 			});
 		});
 	});
-	
+
 
 	var getAttr = function (el, attrName) {
 		return attrName === "class" ?
@@ -570,13 +570,18 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 
 	test("Handlebars helper: unless", function () {
 		var t = {
-			template: "{{#unless missing}}Andy is missing!{{/unless}}",
-			expected: "Andy is missing!",
+			template: "{{#unless missing}}Andy is missing!{{/unless}}" +
+					  "{{#unless isCool}} But he wasn't cool anyways.{{/unless}}",
+			expected: "Andy is missing! But he wasn't cool anyways.",
 			data: {
 				name: 'Andy'
 			},
 			liveData: new can.Map({
-				name: 'Andy'
+				name: 'Andy',
+				// #1202 #unless does not work with computes
+				isCool: can.compute(function () {
+					return t.liveData.attr("missing");
+				})
 			})
 		};
 
@@ -717,7 +722,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 				});
 
 		ok(result.indexOf("<img\n class=\"a\"") !== -1, "Multi-line elements render correctly.");
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	})
@@ -955,7 +960,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		Todos.splice(0, 2);
 		equal(div.getElementsByTagName('option')
 			.length, 0, '0 items in list');
-			
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	});
@@ -999,7 +1004,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		obs.nest.attr('what', 'g');
 
 		equal(getAttr(innerDiv, 'class'), "afcg", 'nested observe');
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	});
@@ -1042,7 +1047,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		});
 
 		equal(div.childNodes[0].innerHTML, 'c', 'updated values');
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	});
@@ -1114,7 +1119,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		equal(p.getAttribute("some"), "newText", 'value in block statement updated attr');
 		equal(getAttr(p, "class"), "newClass", 'value in block statement updated class');
 		equal(span.innerHTML, 'Warp drive, Mr. Sulu', 'value in block statement updated innerHTML');
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 
@@ -1154,7 +1159,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		obs.attr('baz', '');
 		equal(getAttr(anchor, 'class'), "", 'anchor class blank');
 		equal(anchor.getAttribute('some'), undefined, 'attribute "some" is undefined');
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	});
@@ -1184,7 +1189,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 
 		obs.attr('foo', 'data-bar="baz"');
 		equal(anchor.getAttribute('data-bar'), 'baz');
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	});
@@ -1206,7 +1211,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		var div = document.createElement('div');
 		div.appendChild(can.view.frag(compiled));
 		equal(div.getElementsByTagName('div')[0].innerHTML, 'foo', 'Element as expected');
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	})
@@ -1242,7 +1247,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 
 		ok(child.className.indexOf("true") !== -1, "is complete")
 		equal(child.innerHTML, "New Name", "has new name");
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 
@@ -1923,16 +1928,16 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 			div = document.createElement('div');
 
 		div.appendChild(renderer2(plainData));
-		
+
 		equal(div.getElementsByTagName('span')[0].innerHTML, "Dishes", 'Array item rendered with DOM container');
 		equal(div.getElementsByTagName('span')[1].innerHTML, "Forks", 'Array item rendered with DOM container');
 
 		div = document.createElement('div')
 		div.appendChild(renderer2(liveData));
-		
+
 		equal(div.getElementsByTagName('span')[0].innerHTML, "Dishes", 'List item rendered with DOM container');
 		equal(div.getElementsByTagName('span')[1].innerHTML, "Forks", 'List item rendered with DOM container');
-		
+
 		div = document.createElement('div');
 
 		div.appendChild(renderer(plainData));
@@ -2178,7 +2183,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 				"<option data-view-id='[0-9]+'>Two</option></select></textarea>$";
 
 		ok(compiled.search(expected) === 0, "Rendered output is as expected");
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	});
@@ -2721,7 +2726,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		data.attr("image", url);
 		notEqual(img.src, "", 'Image should have src');
 		equal(img.src, url, "images src is correct");
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	});
@@ -2747,7 +2752,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		data.attr("image", imgData);
 		notEqual(img.src, "", 'Image should have src');
 		equal(img.src, url, "images src is correct");
-		
+
 		// clear hookups b/c we are using .render;
 		can.view.hookups = {};
 	});
@@ -3621,7 +3626,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 				window.html5.elements += ' my-custom';
 				window.html5.shivDocument();
 			}
-			
+
 			var oldlog = can.dev.warn;
 			can.dev.warn = function (text) {
 				equal(text, 'can/view/scanner.js: No custom element found for my-custom',
@@ -3823,7 +3828,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 	})
 
 	test("can.Construct derived classes should be considered objects, not functions (#450)", 8, function() {
-		
+
 		can.Mustache.registerHelper("cat", function(options) {
 			var clazz = options.hash ? options.hash.clazz : options;
 			// When using the anonymous function containing foostructor, it will need to be executed
@@ -3839,7 +3844,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 			},
 			div = document.createElement("div"),
 			description;
-			
+
 		foostructor.self = foostructor;
 		window.other_text = "Window context";
 
@@ -3864,7 +3869,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 		var content = div.getElementsByTagName('div');
 
 		description = " (constructor by itself)";
-		
+
 		equal(content[0].innerHTML, "bar", "fully dotted" + description);
 		equal(content[1].innerHTML.replace(/<\/?span>/ig,''), "", "with attribute nested" + description);
 		equal(content[2].innerHTML, "bar", "passed as an argument to helper" + description);
@@ -4001,7 +4006,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 
 		// Helper evaluated 2nd time...
 		state.attr('list', []);
-		
+
 		// Helper evaluated 3rd time...
 		state.attr('list').push('...')
 

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -1,6 +1,6 @@
 steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 	live = live || can.view.live;
-	
+
 	var resolve = function (value) {
 		if (utils.isObserveLike(value) && utils.isArrayLike(value) && value.attr('length')) {
 			return value;
@@ -10,16 +10,16 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			return value;
 		}
 	};
-	
+
 	var helpers = {
 		"each": function(items, options){
-			
+
 			var resolved = resolve(items),
 				result = [],
 				keys,
 				key,
 				i;
-			
+
 			if( resolved instanceof can.List ) {
 				return function(el){
 					// make a child nodeList inside the can.view.live.html nodeList
@@ -28,18 +28,18 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 					nodeList.expression = "live.list";
 					can.view.nodeLists.register(nodeList, null, options.nodeList);
 					can.view.nodeLists.update(options.nodeList, [el]);
-					
+
 					var cb = function (item, index, parentNodeList) {
-								
+
 						return options.fn(options.scope.add({
 								"@index": index
 							}).add(item), options.options, parentNodeList);
-							
+
 					};
 					live.list(el, items, cb, options.context, el.parentNode, nodeList);
 				};
 			}
-			
+
 			var expr = resolved;
 
 			if ( !! expr && utils.isArrayLike(expr)) {
@@ -67,10 +67,10 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 						})
 						.add(expr[key])));
 				}
-				
+
 			}
 			return result;
-			
+
 		},
 		"@index": function(offset, options) {
 			if (!options) {
@@ -122,7 +122,10 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			return helpers.is.apply(this, arguments);
 		},
 		'unless': function (expr, options) {
-			return helpers['if'].apply(this, [can.isFunction(expr) ? can.compute(function() { return !expr(); }) : !expr, options]);
+			return helpers['if'].apply(this, [expr, can.extend({}, options, {
+				fn: options.inverse,
+				inverse: options.fn
+			})]);
 		},
 		'with': function (expr, options) {
 			var ctx = expr;
@@ -145,12 +148,12 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			// Get the argument before that.
 			var data = arguments.length === 2 ? this : arguments[1];
 			return function(el){
-				
+
 				can.data( can.$(el), attr, data || this.context );
 			};
 		}
 	};
-	
+
 	return {
 		registerHelper: function(name, callback){
 			helpers[name] = callback;
@@ -165,5 +168,5 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			}
 		}
 	};
-	
+
 });

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -1,17 +1,17 @@
 /* jshint asi:true,multistr:true*/
 steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","steal-qunit",function(){
-	
-	
+
+
 	QUnit.module("can/view/stache",{
 		setup: function(){
 			can.view.ext = '.stache';
 			this.animals = ['sloth', 'bear', 'monkey'];
 		}
 	});
-	
-	
+
+
 	// HELPERS
-	
+
 	var getText = function(template, data, options){
 		var div = document.createElement("div");
 		div.appendChild( can.stache(template)(data) );
@@ -37,97 +37,97 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 					txt += getTextFromFrag(node);
 				}
 			});
-			
+
 			return txt;
 		};
-	
-	
-	
+
+
+
 	test("html to html", function(){
-		
+
 		var stashed = can.stache("<h1 class='foo'><span>Hello World!</span></h1>");
-		
-		
+
+
 		var frag = stashed();
 		equal(frag.childNodes[0].innerHTML.toLowerCase(), "<span>hello world!</span>","got back the right text");
 	});
-	
-	
+
+
 	test("basic replacement", function(){
-		
+
 		var stashed = can.stache("<h1 class='foo'><span>Hello {{message}}!</span></h1>");
-		
-		
+
+
 		var frag = stashed({
 			message: "World"
 		});
 		equal(frag.childNodes[0].innerHTML.toLowerCase(), "<span>hello world!</span>","got back the right text");
 	});
-	
-	
+
+
 	test("a section helper", function(){
-		
-		
+
+
 		can.stache.registerHelper("helper", function(options){
-			
+
 			return options.fn({message: "World"});
-			
+
 		});
-		
+
 		var stashed = can.stache("<h1 class='foo'>{{#helper}}<span>Hello {{message}}!</span>{{/helper}}</h1>");
-		
-		
+
+
 		var frag = stashed({});
 		equal(frag.childNodes[0].childNodes[0].nodeName.toLowerCase(), "span", "got a span");
-		
+
 		equal(frag.childNodes[0].childNodes[0].innerHTML, "Hello World!","got back the right text");
-		
+
 	});
-	
+
 	test("attribute sections", function(){
 		var stashed = can.stache("<h1 style='top: {{top}}px; left: {{left}}px; background: rgb(0,0,{{color}});'>Hi</h1>");
-		
+
 		var frag = stashed({
 			top: 1,
 			left: 2,
 			color: 3
 		});
-		
+
 		equal(frag.childNodes[0].style.top, "1px", "top works");
 		equal(frag.childNodes[0].style.left, "2px", "left works");
 		equal(frag.childNodes[0].style.backgroundColor.replace(/\s/g,""), "rgb(0,0,3)", "color works");
 	});
-	
+
 	test("attributes sections", function(){
 		var template = can.stache("<div {{attributes}}/>");
 		var frag = template({
 			attributes: "foo='bar'"
 		});
-		
+
 		equal(frag.childNodes[0].getAttribute('foo'), "bar", "set attribute");
-		
+
 		template = can.stache("<div {{#truthy}}foo='{{baz}}'{{/truthy}}/>");
-		
+
 		frag = template({
 			truthy: true,
 			baz: "bar"
 		});
-		
+
 		equal(frag.childNodes[0].getAttribute('foo'), "bar", "set attribute");
-		
+
 		frag = template({
 			truthy: false,
 			baz: "bar"
 		});
-		
+
 		equal(frag.childNodes[0].getAttribute('foo'), null, "attribute not set if not truthy");
-		
-		
+
+
 	});
-	
-	
+
+
 	test("boxes example", function(){
-		
+
 		var boxes = [],
 			Box = can.Map.extend({
 				count: 0,
@@ -152,7 +152,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 				number: i
 			}));
 		}
-		
+
 		var stashed = can.stache("{{#each boxes}}"+
 				"<div class='box-view'>"+
 					"<div class='box' id='box-{{number}}'  style='top: {{top}}px; left: {{left}}px; background: rgb(0,0,{{color}});'>"+
@@ -160,22 +160,22 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 					"</div>"+
 				"</div>"+
 			"{{/each}}");
-		
+
 		var frag = stashed({
 			boxes: boxes
 		});
-		
+
 		//equal(frag.children.length, 2, "there are 2 childNodes");
-		
+
 		equal(frag.childNodes[0].childNodes[0].style.top, "0px");
-		
+
 		boxes[0].tick();
-		
+
 		ok(frag.childNodes[0].childNodes[0].style.top !== "0px");
-		
+
 	});
-	
-	
+
+
 	var override = {
 		comments: {
 			'Standalone Without Newline': '!',
@@ -223,7 +223,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 				} else if(spec === 'partials'){
 					//expected = expected.replace(/\</g,"&lt;").replace(/\>/g,"&gt;")
 				}
-				
+
 
 				// register the partials in the spec
 				if (t.partials) {
@@ -237,13 +237,13 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 					t.data.lambda = eval('(' + t.data.lambda.js + ')');
 				}
 				var res = can.stache(t.template)(t.data);
-				
+
 				deepEqual(getTextFromFrag(res), expected);
 			});
 		});
 	});
 
-	
+
 
 	test('Tokens returning 0 where they should diplay the number', function () {
 		var template = "<div id='zero'>{{completed}}</div>";
@@ -297,7 +297,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		teacher.attr('name', '<i>Mr Scott</i>');
 
 		deepEqual(can.$('#binder1')[0].innerHTML, "&lt;i&gt;Mr Scott&lt;/i&gt;");
-		
+
 		deepEqual(can.$('#binder2')[0].getElementsByTagName('i')[0].innerHTML, "Mr Scott");
 
 		can.remove(can.$('#qunit-fixture>*'));
@@ -355,7 +355,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
-		
+
 		deepEqual( getText(t.template, t.data) , expected);
 	});
 
@@ -391,12 +391,12 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		var template = can.stache(t.template)
 		var frag = template(t.data);
-		
+
 		var div = document.createElement("div");
 		div.appendChild(frag);
 
 		equal(div.innerHTML, t.expected);
-		
+
 		equal(getText(t.template, {}), t.expected2);
 	});
 
@@ -433,7 +433,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 	test("No arguments passed to helper", function () {
 		var template = can.stache("{{noargHelper}}")
-		
+
 		can.stache.registerHelper("noargHelper", function () {
 			return "foo"
 		})
@@ -596,13 +596,18 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 	test("Handlebars helper: unless", function () {
 		var t = {
-			template: "{{#unless missing}}Andy is missing!{{/unless}}",
-			expected: "Andy is missing!",
+			template: "{{#unless missing}}Andy is missing!{{/unless}}" +
+					  "{{#unless isCool}} But he wasn't cool anyways.{{/unless}}",
+			expected: "Andy is missing! But he wasn't cool anyways.",
 			data: {
 				name: 'Andy'
 			},
 			liveData: new can.Map({
-				name: 'Andy'
+				name: 'Andy',
+				// #1202 #unless does not work with computes
+				isCool: can.compute(function () {
+					return t.liveData.attr("missing");
+				})
 			})
 		};
 
@@ -632,13 +637,13 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		var expected = t.expected.replace(/&quot;/g, '&#34;')
 			.replace(/\r\n/g, '\n');
-		
+
 		deepEqual( getText(t.template,t.data) , expected);
 
 		var div = document.createElement('div');
-		
+
 		div.appendChild(can.stache(t.template)(t.data2));
-		
+
 		deepEqual(div.innerHTML, expected, 'Using Observe.List');
 		t.data2.names.push('What');
 	});
@@ -692,7 +697,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 	test("multi line elements", function () {
 		var text = "<div\n class=\"{{myClass}}\" />",
 			result = can.stache(text)({myClass: 'a'});
-		
+
 		equal(result.childNodes[0].className, "a", "class name is right");
 	});
 
@@ -700,7 +705,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		var text = "<span>{{ tags }}</span><label>&amp;</label><strong>{{ number }}</strong><input value='{{ quotes }}'/>";
 
 		var div = document.createElement('div');
-		
+
 		div.appendChild( can.stache(text)({
 			tags: "foo < bar < car > zar > poo",
 			quotes: "I use 'quote' fingers & &amp;ersands \"a lot\"",
@@ -762,11 +767,11 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			id: 1,
 			name: 'Dishes'
 		}]);
-		
+
 		div = document.createElement('div');
 
 		div.appendChild( can.stache(text)({todos: todos}) );
-		
+
 		equal(div.getElementsByTagName('option')
 			.length, 1, '1 item in list')
 
@@ -892,10 +897,10 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		obs.removeAttr('attributes');
 
 		equal(p.getAttribute('some'), null, 'attribute is undefined');
-		
+
 		obs.attr('attributes', 'some="newText"');
 
-		// 
+		//
 		equal(p.getAttribute('some'), 'newText', 'attribute updated');
 
 		obs.removeAttr('message');
@@ -1040,7 +1045,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		ul.appendChild(compiled);
 
 		equal(ul.getElementsByTagName('li')[0].innerHTML, 'No items', 'initial observable state');
-		
+
 		obs.attr('items', [{
 			name: 'foo'
 		}]);
@@ -1550,7 +1555,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 	// https://github.com/bitovi/canjs/issues/228
 	test("Contexts within helpers not always resolved correctly", function () {
-		
+
 		can.stache.registerHelper("bad_context", function (context, options) {
 			return ["<span>"+this.text+"</span> should not be ",options.fn(context)];
 		});
@@ -1566,7 +1571,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			div = document.createElement('div');
 
 		div.appendChild(renderer(data));
-		
+
 		equal(div.getElementsByTagName('span')[0].innerHTML, "foo", 'Incorrect context passed to helper');
 		equal(div.getElementsByTagName('span')[1].innerHTML, "bar", 'Incorrect text in helper inner template');
 		equal(div.getElementsByTagName('span')[2].innerHTML, "In the inner context", 'Incorrect other_text in helper inner template');
@@ -1592,7 +1597,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 	// https://github.com/bitovi/canjs/issues/231
 	test("Functions and helpers should be passed the same context", function () {
-		
+
 		var textNodes = function(el, cb) {
 			can.each(el.childNodes, function(el){
 				if(el.nodeType === 3) {
@@ -1602,7 +1607,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 				}
 			})
 		}
-		
+
 		can.stache.registerHelper("to_upper", function (fn, options) {
 			if (!fn.fn) {
 				return typeof fn === "function" ? fn()
@@ -1629,7 +1634,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 				}
 			},
 			div = document.createElement('div');
-			
+
 		window.other_text = 'Window context';
 
 		div.appendChild(renderer(data));
@@ -1676,7 +1681,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		div.appendChild(renderer(liveData));
 		equal(div.innerHTML, "DishesForks", 'List item rendered without DOM container');
-		
+
 		liveData.todos.push({
 			id: 3,
 			name: 'Knives'
@@ -1820,9 +1825,9 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 				name: fancyName
 			}
 		});
-		
-		
-		
+
+
+
 		ok(/World/.test(result.childNodes[0].innerHTML), "Hello World worked");
 	});
 
@@ -2035,7 +2040,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		deepEqual( getText( t.template, t.data), expected);
 	});
 
-	
+
 	test("avoid global helpers", function () {
 
 		var noglobals = can.stache("{{sometext person.name}}");
@@ -2066,9 +2071,9 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		equal(div.innerHTML, "Mr. Ajax");
 		equal(div2.innerHTML, "Ajax rules");
-		
+
 	});
-	
+
 
 	test("Each does not redraw items", function () {
 
@@ -2146,7 +2151,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		equal(div.getElementsByTagName('span')
 			.length, 1, "There is 1 sloth");
-			
+
 		animals.pop();
 
 		equal(div.getElementsByTagName('div')[0].innerHTML, "Animals:No animals!");
@@ -2560,7 +2565,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			url = "http://google.com/",
 			templateEscape = can.stache('{{link "' + text + '" "' + url + '"}}'),
 			templateUnescape = can.stache('{{{link "' + text + '" "' + url + '"}}}');
-		
+
 		can.stache.registerHelper('link', function (text, url) {
 			var link = '<a href="' + url + '">' + text + '</a>';
 			return can.stache.safeString(link);
@@ -2570,7 +2575,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		div.appendChild(templateEscape({}));
 
 		equal(div.children.length, 1, 'rendered a DOM node');
-		
+
 		equal(div.children[0].nodeName, 'A', 'rendered an anchor tag');
 		equal(div.children[0].innerHTML, text, 'rendered the text properly');
 		equal(div.children[0].getAttribute('href'), url, 'rendered the href properly');
@@ -2968,7 +2973,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			.push('second');
 
 		equal(labels.length, 2, "after pushing two label");
-		
+
 		data.removeAttr('item');
 
 		equal(labels.length, 0, "after removing item no label");
@@ -2995,7 +3000,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			bindings++;
 			return can.Map.prototype.bind.apply(this, arguments);
 		}
-		
+
 		// unbind will be called twice
 		function unbind(eventType) {
 			can.Map.prototype.unbind.apply(this, arguments);
@@ -3210,7 +3215,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 	});
 
 	test("{{#each}} handles an undefined list changing to a defined list (#629)", function () {
-		
+
 		var renderer = can.stache('    {{description}}: \
 		<ul> \
 		{{#each list}} \
@@ -3237,7 +3242,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		stop();
 		setTimeout(function () {
-			
+
 			start();
 			data1.attr('list', [{
 				name: 'first'
@@ -3245,10 +3250,10 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			data2.attr('list', [{
 				name: 'first'
 			}]);
-			
+
 			equal(div.getElementsByTagName('ul')[0].getElementsByTagName('li')
 				.length, 1, "there should be an li as we set an attr to an array");
-				
+
 			equal(div.getElementsByTagName('ul')[1].getElementsByTagName('li')
 				.length, 1);
 			equal(div.getElementsByTagName('ul')[0].getElementsByTagName('li')[0].innerHTML, 'first');
@@ -3315,7 +3320,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		equal(labels.length, 1, "first label removed")
 	});
-	
+
 	test("#each with #if directly nested (#750)", function(){
 		var template = can.stache("<ul>{{#each list}} {{#if visible}}<li>{{name}}</li>{{/if}} {{/each}}</ul>");
 		var data = new can.Map(
@@ -3335,74 +3340,74 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 					}
 				]
 			});
-		
+
 		var frag = template(data);
-		
+
 		data.attr('list').pop();
-		
+
 		equal(frag.childNodes[0].getElementsByTagName('li').length, 1, "only first should be visible")
-		
+
 	});
-	
+
 	test("can.view.tag", function(){
-		
+
 		expect(4);
-		
+
 		can.view.tag("stache-tag", function(el, tagData){
 			ok(tagData.scope instanceof can.view.Scope, "got scope");
 			ok(tagData.options instanceof can.view.Scope, "got options");
 			equal(typeof tagData.subtemplate, "function", "got subtemplate");
 			var frag = tagData.subtemplate(tagData.scope.add({last: "Meyer"}), tagData.options);
-			
+
 			equal( frag.childNodes[0].innerHTML, "Justin Meyer", "rendered right");
 		});
-		
+
 		var template = can.stache("<stache-tag><span>{{first}} {{last}}</span></stache-tag>")
-		
+
 		template({first: "Justin"});
-		
+
 	})
-	
+
 	test("can.view.attr", function(){
-		
+
 		expect(3);
-		
+
 		can.view.attr("stache-attr", function(el, attrData){
 			ok(attrData.scope instanceof can.view.Scope, "got scope");
 			ok(attrData.options instanceof can.view.Scope, "got options");
 			equal(attrData.attributeName, "stache-attr", "got attribute name");
-			
+
 		});
-		
+
 		var template = can.stache("<div stache-attr='foo'></div>");
-		
+
 		template({});
-		
+
 	});
-	
+
 	if(window.jQuery || window.Zepto) {
-		
+
 		test("helpers returning jQuery or Zepto collection", function(){
-			
+
 			can.stache.registerHelper("jQueryHelper", function(options){
 				var section = options.fn({first: "Justin"});
 				return $("<h1>").append( section );
 			});
-			
+
 			var template = can.stache( "{{#jQueryHelper}}{{first}} {{last}}{{/jQueryHelper}}");
-			
+
 			var res = template({last: "Meyer"});
-			
+
 			equal(res.childNodes[0].nodeName.toLowerCase(), "h1");
-			
+
 			equal(res.childNodes[0].innerHTML, "Justin Meyer");
-			
+
 		});
 	}
-	
+
 	test("./ in key", function(){
 		var template = can.stache( "<div><label>{{name}}</label>{{#children}}<span>{{./name}}-{{name}}</span>{{/children}}</div>");
-		
+
 		var data = {
 			name: "CanJS",
 			children: [{},{name: "stache"}]
@@ -3412,48 +3417,48 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		equal( spans[0].innerHTML, "-CanJS", "look in current level" );
 		equal( spans[1].innerHTML, "stache-stache", "found in current level" );
 	});
-	
+
 	test("self closing tags callback custom tag callbacks (#880)", function(){
-		
+
 		can.view.tag("stache-tag", function(el, tagData){
 			ok(true,"tag callback called");
 			equal(tagData.scope.attr(".").foo, "bar", "got scope");
 			ok(!tagData.subtemplate, "there is no subtemplate");
 		});
-		
+
 		var template = can.stache("<div><stache-tag/></div>");
-		
+
 		template({
 			foo: "bar"
 		});
-		
+
 	});
-	
+
 	test("empty custom tags do not have a subtemplate (#880)", function(){
-		
+
 		can.view.tag("stache-tag", function(el, tagData){
 			ok(true,"tag callback called");
 			equal(tagData.scope.attr(".").foo, "bar", "got scope");
 			ok(!tagData.subtemplate, "there is no subtemplate");
 		});
-		
+
 		var template = can.stache("<div><stache-tag></stache-tag></div>");
-		
+
 		template({
 			foo: "bar"
 		});
-		
+
 	});
 
 	test("inverse in tag", function(){
 		var template = can.stache('<span {{^isBlack}} style="display:none"{{/if}}>Hi</span>');
-		
+
 		var res = template({
 			isBlack: false
 		});
-		
+
 		equal(res.childNodes[0].style.display, "none", "color is not set");
-		
+
 	});
 
 	//!steal-remove-start
@@ -3595,13 +3600,13 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			'</svg>';
 		var frag = can.stache(template)({});
 
-		
+
 		equal(frag.childNodes[0].childNodes[0].getAttribute("r"), "25");
 	});
-	
+
 	test("single property read does not infinately loop (#1155)",function(){
 		stop();
-		
+
 		var map = new can.Map({state: false});
 		var current = false;
 		var source = can.compute(1)
@@ -3612,9 +3617,9 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			return source();
 		});
 		number.bind("change",function(){});
-		
+
 		var template = can.stache("<div>{{#if map.state}}<span>Hi</span>{{/if}}</div>")
-		
+
 		template({
 			map: map
 		});
@@ -3622,11 +3627,11 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		map.attr("state", current = !current);
 		ok(true,"no error at this point");
 		start();
-		
+
 	});
-	
+
 	test("methods become observable (#1164)", function(){
-		
+
 		var TeamModel = can.Map.extend({
 
 			shortName : function() {
@@ -3675,11 +3680,11 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		list.splice(-1);
 		equal(frag.childNodes.length, children - 1, 'Child node removed');
 	});
-	
+
 	test('stache can accept an intermediate (#1387)', function(){
 		var template = "<div class='{{className}}'>{{message}}</div>";
 		var intermediate = can.view.parser(template,{}, true);
-		
+
 		var renderer = can.stache(intermediate);
 		var frag = renderer({className: "foo", message: "bar"});
 		equal(frag.childNodes[0].className, "foo", "correct class name");
@@ -3705,53 +3710,53 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		equal(div.childNodes[0].innerHTML, "goodbye World", "Partial updates when attr is updated");
 
 	});
-	
+
 	test("#each with null or undefined and then a list", function(){
 		var template = can.stache("<ul>{{#each items}}<li>{{name}}</li>{{/each}}");
 		var data = new can.Map({items: null});
 		var frag = template(data);
-		
+
 		var div = document.createElement("div");
 		div.appendChild(frag);
-		
-		
+
+
 		data.attr("items", [{name: "foo"}]);
-		
+
 		equal(div.getElementsByTagName("li").length, 1, "li added");
 	});
-	
+
 	test("promises work (#179)", function(){
-		
+
 		var template = can.stache(
 			"{{#if promise.isPending}}<span class='pending'></span>{{/if}}"+
 			"{{#if promise.isRejected}}<span class='rejected'>{{promise.reason.message}}</span>{{/if}}"+
 			"{{#if promise.isResolved}}<span class='resolved'>{{promise.value.message}}</span>{{/if}}");
-		
+
 		var def = new can.Deferred();
 		var data = {
 			promise: def.promise()
 		};
-		
+
 		var frag = template(data);
 		var div = document.createElement("div");
 		div.appendChild(frag);
-		
+
 		var spans = div.getElementsByTagName("span");
-		
+
 		equal(spans.length, 1);
 		equal(spans[0].className, "pending");
-		
+
 		stop();
-		
+
 		def.resolve({message: "Hi there"});
-		
+
 		// better than timeouts would be using can-inserted, but we don't have can/view/bindings
 		setTimeout(function(){
 			equal(spans.length, 1);
 			equal(spans[0].className, "resolved");
 			equal(spans[0].innerHTML, "Hi there");
-			
-			
+
+
 			var def = new can.Deferred();
 			var data = {
 				promise: def.promise()
@@ -3760,74 +3765,74 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			var div = document.createElement("div");
 			div.appendChild(frag);
 			spans = div.getElementsByTagName("span");
-			
+
 			def.reject({message: "BORKED"});
-			
+
 			setTimeout(function(){
 				equal(spans.length, 1);
 				equal(spans[0].className, "rejected");
 				equal(spans[0].innerHTML, "BORKED");
-				
+
 				start();
 			}, 30);
 		},30);
-		
+
 	});
-	
+
 	test("{#list} works right (#1551)", function(){
 		var data = new can.Map({});
 		var template = can.stache("<div>{{#items}}<span/>{{/items}}</div>");
 		var frag = template(data);
-		
+
 		data.attr("items",new can.List());
-		
+
 		data.attr("items").push("foo");
-		
+
 		var spans = frag.childNodes[0].getElementsByTagName("span");
-		
+
 		equal(spans.length,1, "one span");
-		
+
 	});
-	
+
 	test("promises are not rebound (#1572)", function(){
 		stop();
 		var d = new can.Deferred();
-		
+
 		var compute = can.compute(d);
-		
+
 		var template = can.stache("<div>{{#if promise.isPending}}<span/>{{/if}}</div>");
 		var frag = template({
 			promise: compute
 		});
 		var div = frag.childNodes[0],
 			spans = div.getElementsByTagName("span");
-		
+
 		var d2 = new can.Deferred();
 		compute(d2);
-		
+
 		setTimeout(function(){
 			d2.resolve("foo");
-			
+
 			setTimeout(function(){
 				equal(spans.length, 0, "there should be no spans");
 				start();
 			},30);
 		},10);
-		
+
 	});
-	
+
 	test("reading alternate values on promises (#1572)", function(){
 		var promise = new can.Deferred();
 		promise.myAltProp = "AltValue";
-		
+
 		var template = can.stache("<div>{{d.myAltProp}}</div>");
-		
+
 		var frag = template({d: promise});
-		
+
 		equal(frag.childNodes[0].innerHTML, "AltValue", "read value");
-		
+
 	});
-	
+
 	test("don't setup live binding for raw data with seciton helper", function () {
 		expect(0);
 		var template = can.stache("<ul>{{#animals}}" +
@@ -3845,10 +3850,10 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		template({
 			animals: this.animals
 		});
-		
+
 		can.bind = oldBind;
 	});
-	
+
 	test("possible to teardown immediate nodeList (#1593)", function(){
 		// show will be bound and unbound twice as computeData switches to the
 		// faster algorithim.  In the future, it might be possible to prevent
@@ -3857,7 +3862,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		var map = new can.Map({show: true});
 		var oldBind = map.bind,
 			oldUnbind = map.unbind;
-			
+
 		map.bind = function(){
 			ok(true, "bound");
 			return oldBind.apply(this, arguments);
@@ -3866,25 +3871,25 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			ok(true, "unbound");
 			return oldUnbind.apply(this, arguments);
 		};
-		
+
 		var template = can.stache("{{#if show}}<span/>TEXT{{/if}}");
 		var nodeList = can.view.nodeLists.register([], undefined, true);
 		var frag = template(map,{},nodeList);
 		can.view.nodeLists.update(nodeList, frag.childNodes);
-		
+
 		equal(nodeList.length, 1, "our nodeList has the nodeList of #if show");
-		
+
 		can.view.nodeLists.unregister(nodeList);
-		
+
 		// has to be async b/c of the temporary bind for performance
 		stop();
 		setTimeout(function(){
 			start();
 		},10);
-		
+
 	});
-	
-		// the define test doesn't include the stache plugin and 
+
+		// the define test doesn't include the stache plugin and
 	// the stache test doesn't include define plugin, so have to put this here
 	test('#1590 #each with surrounding block and setter', function(){
 		// the problem here ... is that a batch is happening
@@ -3900,11 +3905,11 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			people: people,
 			product: product
 		});
-		
+
 		can.batch.start();
 		product(1);
 		can.batch.stop();
-		
+
 		equal(frag.childNodes[0].getElementsByTagName('span').length, 1, "no duplicates");
 
 	});
@@ -3917,7 +3922,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 			var frag = template({
 				radius: 6
 			});
-			
+
 			equal(frag.childNodes[0].namespaceURI, "http://www.w3.org/2000/svg", "svg namespace");
 		});
 	}
@@ -3925,7 +3930,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 	test('using #each when toggling between list and null', function() {
 		var state = new can.Map();
 		var frag = can.stache('{{#each deepness.rows}}<div></div>{{/each}}')(state);
-		
+
 		state.attr('deepness', {
 			rows: ['test']
 		});
@@ -3933,19 +3938,19 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 
 		equal(frag.childNodes.length, 1, "only the placeholder textnode");
 	});
-	
+
 	test("compute defined after template (#1617)", function(){
 		var myMap = new can.Map();
 
 		// 1. Render a stache template with a binding to a key that is not a can.compute
 		var frag = can.stache('<span>{{ myMap.test }}</span>')({myMap: myMap});
-		
+
 		// 2. Set that key to a can.compute
 		myMap.attr('test', can.compute(function() { return "def"; }));
 
 		equal(frag.firstChild.firstChild.nodeValue, "def", "correct value");
 	});
-	
+
 
 	test('template with a block section and nested if doesnt render correctly', function() {
 		var myMap = new can.Map({

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -597,7 +597,7 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 	test("Handlebars helper: unless", function () {
 		var t = {
 			template: "{{#unless missing}}Andy is missing!{{/unless}}" +
-					  "{{#unless isCool}} But he wasn't cool anyways.{{/unless}}",
+			          "{{#unless isCool}} But he wasn't cool anyways.{{/unless}}",
 			expected: "Andy is missing! But he wasn't cool anyways.",
 			data: {
 				name: 'Andy'


### PR DESCRIPTION
A demo page can be found here: http://jsbin.com/pucucidofa/edit?html,js,output

The change involves making the `unless` helper a proxy to the `if` helper, but it flips the `fn` and `inverse` properties. All tests were updated to first expose the bug, and then the fix was implemented.