### PR TITLE
fixes #1891 by making executeAnonFuncs default to true

### DIFF
--- a/compute/read.js
+++ b/compute/read.js
@@ -1,14 +1,12 @@
 steal("can/util", function(can){
 	
 	
-	
-	
 	// there are things that you need to evaluate when you get them back as a property read
 	// for example a compute or a function you might need to call to get the next value to 
 	// actually check
 	// - isArgument - should be renamed to something like "onLastPropertyReadReturnFunctionInsteadOfCallingIt".
 	//   This is used to make a compute out of that function if necessary.
-	// - executeAnonymousFunctions - call a function if it's found
+	// - executeAnonymousFunctions - call a function if it's found, defaults to true
 	// - proxyMethods - if the last read is a method, return a function so `this` will be correct.
 	// - args - arguments to call functions with.
 	// - returnObserveMethods - return the function on an observable instead of trying to call it.
@@ -115,7 +113,7 @@ steal("can/util", function(can){
 			var type = typeof value;
 			// i = reads.length if this is the last iteration of the read for-loop.
 			return type === 'function' && !value.isComputed &&
-				(options.executeAnonymousFunctions || (options.isArgument && i === reads.length) ) &&
+				(options.executeAnonymousFunctions !== false || (options.isArgument && i === reads.length) ) &&
 				!(can.Construct && value.prototype instanceof can.Construct) &&
 				!(can.route && value === can.route);
 		},

--- a/test/builders/steal-tools/test.js
+++ b/test/builders/steal-tools/test.js
@@ -46,7 +46,7 @@ var open = function(url, callback, done){
 };
 
 describe("Building steal projects", function(){
-	this.timeout(5000);
+	this.timeout(20000);
 
 	it("works with ejs, mustache, and stache", function(done){
 			rmdir(__dirname+"/bundles", function(error){

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -190,8 +190,7 @@ steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can
 				// we'll call.
 				var scopeData = data.scope.read(attrInfo.name.key, {
 					returnObserveMethods: true,
-					isArgument: true,
-					executeAnonymousFunctions: true
+					isArgument: true
 				});
 
 				// We break out early if the first argument isn't available

--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -291,9 +291,7 @@ steal(
 									currentSetReads = currentReads;
 									setObserveDepth = nameIndex;
 								}
-							},
-							// Execute anonymous functions found along the way
-							executeAnonymousFunctions: true
+							}
 						}, options);
 
 					// Goes through each scope context provided until it finds the key (attr).  Once the key is found

--- a/view/stache/mustache_core_test.js
+++ b/view/stache/mustache_core_test.js
@@ -121,5 +121,33 @@ steal("./mustache_core.js", "steal-qunit", function(){
 		equal(result(), 5);
 	});
 	
+	test("methods don't update correctly (#1891)", function(){
+		var map = new can.Map({
+		  num: 1,
+		  num2: function () {
+		    return this.attr('num') * 2;
+		  },
+		  runTest: function () {
+		    this.attr('num', this.attr('num') * 2);
+		  }
+		});
+		
+		var scope =
+			new can.view.Scope(map);
+		
+		var num2Expression = new mustacheCore.ScopeExpression("num2");
+		var num2 = num2Expression.value( scope, new can.view.Scope({}), {asCompute: true} );
+		
+		num2.bind("change", function(ev, newVal){
+			
+		});
+		
+		map.runTest();
+		
+		equal( num2(), 4, "num2 updated correctly");
+		
+	});
+	
+	
 	
 });


### PR DESCRIPTION
can.compute.read will executeAnonymousFunctions to true, so even if it's not passed, that behavior is still present. 