### PR TITLE
fixes #1891 by making executeAnonFuncs default to true

### DIFF
--- a/compute/read.js
+++ b/compute/read.js
@@ -106,7 +106,7 @@ steal("can/util", function(can){
 			var type = typeof value;
 			// i = reads.length if this is the last iteration of the read for-loop.
 			return type === 'function' && !value.isComputed &&
-				(options.executeAnonymousFunctions || (options.isArgument && i === reads.length) ) &&
+				(options.executeAnonymousFunctions !== false || (options.isArgument && i === reads.length) ) &&
 				!(can.Construct && value.prototype instanceof can.Construct) &&
 				!(can.route && value === can.route);
 		},

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4038,4 +4038,24 @@ steal("can/view/stache", "can/view", "can/test","can/view/mustache/spec/specs","
 		state.attr('showAttr', false);
 		state.attr('showAttr', true);
 	});
+
+	test("methods don't update correctly (#1891)", function() {
+		var map = new can.Map({
+			num1: 1,
+			num2: function () { return this.attr('num1') * 2; }
+		});
+		var frag = can.stache(
+			'<span class="num1">{{num1}}</span>' +
+			'<span class="num2">{{num2}}</span>')(map);
+
+		can.append(can.$('#qunit-fixture'), frag);
+
+		equal(can.$('#qunit-fixture .num1')[0].innerHTML, '1', 'Rendered correct value');
+		equal(can.$('#qunit-fixture .num2')[0].innerHTML, '2', 'Rendered correct value');
+
+		map.attr('num1', map.attr('num1') * 2);
+
+		equal(can.$('#qunit-fixture .num1')[0].innerHTML, '2', 'Rendered correct value');
+		equal(can.$('#qunit-fixture .num2')[0].innerHTML, '4', 'Rendered correct value');
+	});
 });


### PR DESCRIPTION
Backport this fix (#1901) made in minor, to master for the 2.2.8 release, since it was a regression in 2.2.6 logged here: #1891.

