### PR TITLE
Fixes #1790. Cast element.getAttrs to string in live.js

### DIFF
--- a/view/live/live.js
+++ b/view/live/live.js
@@ -638,7 +638,8 @@ steal('can/util',
 				can.data(wrapped, 'hooks', hooks = {});
 			}
 			// Get the attribute value.
-			var attr = elements.getAttr(el, attributeName),
+			// Cast to String. String expected for rendering. Attr may return other types for some attributes.
+			var attr = String(elements.getAttr(el, attributeName)),
 				// Split the attribute value by the template.
 				// Only split out the first __!!__ so if we have multiple hookups in the same attribute,
 				// they will be put in the right spot on first render

--- a/view/live/live_test.js
+++ b/view/live/live_test.js
@@ -255,6 +255,6 @@ steal("can/view/live", "can/observe", "can/test", "steal-qunit", function () {
 
 		can.view.elements.setAttr(el, "value", 1);
 		can.view.live.attribute(el, 'value', compute);
-		ok(true, 'No exception thrown.')
+		ok(true, 'No exception thrown.');
 	});
 });

--- a/view/live/live_test.js
+++ b/view/live/live_test.js
@@ -235,21 +235,26 @@ steal("can/view/live", "can/observe", "can/test", "steal-qunit", function () {
 				return '<label>Animal=</label> <span>' + animal + '</span>';
 			},
 			unbind = list.unbind;
-			
+
 		list.unbind = function(){
 			ok(false, "unbind called");
 			return unbind.apply(this, arguments);
 		};
-		
+
 		div.innerHTML = 'my <b>fav</b> animals: <span></span> !';
 		var el = div.getElementsByTagName('span')[0];
-		
+
 		can.view.live.list(el, list, template, {});
-		
-		
-		
 	});
-	
-	
-	
+
+	test("can.live.attribute works with non-string attributes (#1790)", function() {
+		var el = document.createElement('div'),
+			compute = can.compute(function() {
+				return 2;
+			});
+
+		can.view.elements.setAttr(el, "value", 1);
+		can.view.live.attribute(el, 'value', compute);
+		ok(true, 'No exception thrown.')
+	});
 });


### PR DESCRIPTION
Fixes #1790. Elements.getAttr correctly returns other types, but string is expected. Added test case that reproduces a non-string attribute being returned and subsequent error. 