### PR TITLE
#1872: map attribute 'for' to 'htmlFor' property

### DIFF
--- a/util/attr/attr.js
+++ b/util/attr/attr.js
@@ -42,9 +42,13 @@ steal("can/util/can.js", function (can) {
 				"value": "value",
 				"innertext": "innerText",
 				"textcontent": "textContent",
+				"for": "htmlFor",
 				"checked": true,
 				"disabled": true,
-				"readonly": true,
+				"readonly": function (el, val) {
+					el.readOnly = true;
+					return val;
+				},
 				"required": true,
 				// For the `src` attribute we are using a setter function to prevent values such as an empty string or null from being set.
 				// An `img` tag attempts to fetch the `src` when it is set, so we need to prevent that from happening by removing the attribute instead.

--- a/util/attr/attr_test.js
+++ b/util/attr/attr_test.js
@@ -1,4 +1,4 @@
-steal('can/util', 'can/view/mustache', 'can/util/attr', 'steal-qunit', function () {
+steal('can/util', 'can/view/stache', 'can/util/attr', 'steal-qunit', function () {
 	QUnit.module("can/util/attr");
 
 	test("attributes event", function () {
@@ -43,7 +43,7 @@ steal('can/util', 'can/view/mustache', 'can/util/attr', 'steal-qunit', function 
 
 	test("template attr updating", function () {
 
-		var template = can.mustache("<div my-attr='{{value}}'></div>"),
+		var template = can.stache("<div my-attr='{{value}}'></div>"),
 			compute = can.compute("foo");
 
 		var div = template({
@@ -81,6 +81,46 @@ steal('can/util', 'can/view/mustache', 'can/util/attr', 'steal-qunit', function 
 		can.attr.set(input, "CHECKED");
 
 		equal(input.checked, true);
+		can.remove(can.$("#qunit-fixture>*"));
+	});
+
+	test("attr.set READONLY property should be set correctly via template binding #1874", function () {
+
+		var template = can.stache('<input type="text" {{#if flag}}READONLY{{/if}}></input>'),
+			compute = can.compute(false);
+
+		var input = template({
+			flag: compute
+		}).childNodes[0];
+
+		equal(input.readOnly, false, "readOnly should be false");
+		compute(true);
+		equal(input.readOnly, true, "readOnly should be set to true");
+		compute(false);
+		equal(input.readOnly, false, "readOnly should be set back to false");
+	});
+
+	test("Map special attributes", function () {
+
+		var div = document.createElement("div");
+
+		document.getElementById("qunit-fixture").appendChild(div);
+
+		can.attr.set(div, "class", "my-class");
+		equal(div.className, "my-class", "Map class to className");
+
+		can.attr.set(div, "for", "my-for");
+		equal(div.htmlFor, "my-for", "Map for to htmlFor");
+
+		can.attr.set(div, "innertext", "my-inner-text");
+		equal(div.innerText, "my-inner-text", "Map innertext to innerText");
+
+		can.attr.set(div, "textcontent", "my-content");
+		equal(div.textContent, "my-content", "Map textcontent to textContent");
+
+		can.attr.set(div, "readonly");
+		equal(div.readOnly, true, "Map readonly to readOnly");
+
 		can.remove(can.$("#qunit-fixture>*"));
 	});
 

--- a/util/attr/test.html
+++ b/util/attr/test.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head> </head>
+<body>
+<div id="qunit"></div>
+<div id="qunit-fixture"></div>
+<script src="../../node_modules/steal/steal.js"
+		data-main="util/attr/attr_test"></script>
+</body>
+</html>


### PR DESCRIPTION
In can.attr added a special attribute mapping 'for' to 'htmlFor' property. Tests added.