### PR TITLE
#1944: on component destroy call its prototype's destroy to teardown

### DIFF
--- a/component/component.js
+++ b/component/component.js
@@ -507,6 +507,7 @@ steal("can/util", "can/view/callbacks","can/view/elements.js","can/control", "ca
 			this._bindings.readyComputes = {};
 		},
 		destroy: function() {
+			can.Control.prototype.destroy.apply( this, arguments );
 			if(typeof this.options.destroy === 'function') {
 				this.options.destroy.apply(this, arguments);
 			}

--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1754,4 +1754,26 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 		var frag = can.stache('<simple-helper></simple-helper>')();
 		equal(frag.childNodes[0].innerHTML, 'Result: 7');
 	});
+
+	test("component destroy should teardown event handlers", function () {
+		var count = 0,
+			map = new can.Map({value: 1});
+
+		can.Component.extend({
+			tag: "page-element",
+			viewModel: { map: map },
+			events: {
+				'{scope.map} value': function(){
+					count++;
+				}
+			}
+		});
+		can.append(can.$("#qunit-fixture"), can.stache("<page-element></page-element>")());
+		can.remove(can.$("#qunit-fixture>*"));
+		map.attr("value", 2);
+
+		equal(count, 0, "Event handler should NOT be called since the element was removed.");
+
+		can.remove(can.$("#qunit-fixture>*"));
+	});
 });


### PR DESCRIPTION
When component is removed its `.destroy` method didn't call `prototype.destroy` thus its `.off` method was not called. This fixes #1944.