### PR TITLE
Rename ~ helper to joinBase

### DIFF
--- a/view/stache/doc/helpers/joinBase.md
+++ b/view/stache/doc/helpers/joinBase.md
@@ -1,7 +1,7 @@
-@function can.stache.helpers.tilde {{~ args}}
+@function can.stache.helpers.joinBase {{joinBase args}}
 @parent can.stache.htags 16
 
-@signature `{{~ expr}}`
+@signature `{{joinBase expr}}`
 
 Return an application-relative url for a resource.
 
@@ -11,15 +11,15 @@ Return an application-relative url for a resource.
 
 @body
 
-The `~` helper is used to create urls within your application for static resources, such as images. An example usage:
+The `joinBase` helper is used to create urls within your application for static resources, such as images. An example usage:
 
-    {{~ "hello/" name ".png"}}
+    {{joinBase "hello/" name ".png"}}
 
 Where `name` is a scope value, this might return `http://example.com/app/hello/world.png` if the application is `http://example.com/app`.
 
 The url to join with is determined by the following factors:
 
-* If attempting to load a relative url, such as `{{~ "../foo.png"}}` and using StealJS the template's address will be used as a reference to look up the location.
+* If attempting to load a relative url, such as `{{joinBase "../foo.png"}}` and using StealJS the template's address will be used as a reference to look up the location.
 * If the `can.baseURL` string is set, this will be used.
 * If the `System.baseURL` is set, this will be used.
 * Lastly we fall back to `location.pathname`.

--- a/view/stache/mustache_helpers.js
+++ b/view/stache/mustache_helpers.js
@@ -167,7 +167,7 @@ steal("can/util", "./utils.js","can/view/live",function(can, utils, live){
 			});
 			return options.fn(options.scope, newOptions);
 		},
-		'~': function(firstExpr/* , expr... */){
+		'joinBase': function(firstExpr/* , expr... */){
 			var args = [].slice.call(arguments);
 			var options = args.pop();
 

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4174,10 +4174,10 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			deepEqual(getTextFromFrag(frag), "Not 10 ducks");
 		});
 
-		test("~ helper joins to the baseURL", function(){
+		test("joinBase helper joins to the baseURL", function(){
 			can.baseURL = "http://foocdn.com/bitovi";
 
-			var template = can.stache("{{~ 'hello/' name}}");
+			var template = can.stache("{{joinBase 'hello/' name}}");
 			var map = new can.Map({ name: "world" });
 
 			var frag = template(map);
@@ -4186,10 +4186,10 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			can.baseUrl = undefined;
 		});
 
-		test("~ helper can be relative to template module", function(){
+		test("joinBase helper can be relative to template module", function(){
 			var baseUrl = "http://foocdn.com/bitovi";
 
-			var template = can.stache("{{~ '../hello/' name}}");
+			var template = can.stache("{{joinBase '../hello/' name}}");
 			var map = new can.Map({ name: "world" });
 
 			var frag = template(map, { module: { uri: baseUrl } });


### PR DESCRIPTION
We need to rename the `~` helper because in 2.3 `~` is going to coerce a
scope value into a compute. Fixes #1932