### PR TITLE
Make can/view/href part of can/view/bindings

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -68,8 +68,9 @@
 		},
 		"can/view/href/href": {
 			"name": "can.view.href",
-			"type": "plugin",
-			"description": "Make flexible route links"
+			"type": "core",
+			"description": "Make flexible route links",
+			"isDefault": true
 		},
 		"can/control/control": {
 			"name": "can.Control",

--- a/view/bindings/bindings.js
+++ b/view/bindings/bindings.js
@@ -3,7 +3,7 @@
 // This file defines the `can-value` attribute for two-way bindings and the `can-EVENT` attribute
 // for in template event bindings. These are usable in any mustache template, but mainly and documented
 // for use within can.Component.
-steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can/control", "can/view/scope", function (can, mustacheCore) {
+steal("can/util", "can/view/stache/mustache_core.js", "can/view/callbacks", "can/control", "can/view/scope", "can/view/href", function (can, mustacheCore) {
 	/**
 	 * @function isContentEditable
 	 * @hide


### PR DESCRIPTION
So that it doesn't have to be imported individually.