### PR TITLE
Specify jQuery's exports in development and the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
 				"meta": {
 					"jquery": {
 						"format": "global",
+						"exports": "jQuery",
 						"deps": [
 							"can/util/vdom/vdom"
 						]
@@ -176,6 +177,7 @@
 				"meta": {
 					"jquery": {
 						"format": "global",
+						"exports": "jQuery",
 						"deps": [
 							"can/util/vdom/vdom"
 						]


### PR DESCRIPTION
This is for https://github.com/donejs/donejs/issues/89.  By setting the
exports we'll fix the iOS bug.