### PR TITLE
Do not use pushstate routing on file:// protocol URLs

### DIFF
--- a/route/pushstate/pushstate.js
+++ b/route/pushstate/pushstate.js
@@ -12,8 +12,11 @@
 steal('can/util', 'can/route', function (can) {
 	"use strict";
 
+	var hasPushstate = window.history && window.history.pushState;
+	var isFileProtocol = window.location && window.location.protocol === 'file:';
+
 	// Initialize plugin only if browser supports pushstate.
-	if ((window.history && history.pushState) || can.isNode) {
+	if ((!isFileProtocol && hasPushstate) || can.isNode) {
 
 		// Registers itself within `can.route.bindings`.
 		can.route.bindings.pushstate = {


### PR DESCRIPTION
Pushstate routing on `file://` URLs doesn't work so we shouldn't load it in that case. This is important for mobile and desktop apps that normally load from the file system. Originally tracked at https://github.com/donejs/donejs/issues/92