### PR TITLE
Remove unneeded can.isNode check

### DIFF
--- a/route/pushstate/pushstate.js
+++ b/route/pushstate/pushstate.js
@@ -16,7 +16,7 @@ steal('can/util', 'can/route', function (can) {
 	var isFileProtocol = window.location && window.location.protocol === 'file:';
 
 	// Initialize plugin only if browser supports pushstate.
-	if ((!isFileProtocol && hasPushstate) || can.isNode) {
+	if (!isFileProtocol && hasPushstate) {
 
 		// Registers itself within `can.route.bindings`.
 		can.route.bindings.pushstate = {


### PR DESCRIPTION
This breaks the app in nw.js and since we shim pushstate on the server the `can.isNode` check isn't necessary at all.