### PR TITLE
fixes a bug with deep methods like foo.bar() in bindings

### DIFF
--- a/component/examples/paginate_next_event.html
+++ b/component/examples/paginate_next_event.html
@@ -24,39 +24,39 @@
 	{{/if}}
 </script>
 </div>
-<script src="../../node_modules/steal/steal.js" main="@empty">
-	import Component from "can/component/";
-	import stache from "can/view/stache/";
-	import $ from "jquery";
-	
-	can.Component.extend({
-		tag: "player-list",
-		template: can.view('player-list-stache'),
-		viewModel: {
-			players: new can.List([{name: "Justin"},{name: "Brian"}]),
-			editPlayer: function(player){
-				this.attr("editingPlayer", player);
-			},
-			removeEdit: function(){
-				this.removeAttr("editingPlayer");
-			},
-			isEditing: function(player){
-				return this.attr("editingPlayer") === player;
-			}
+<script src="../../node_modules/steal/steal.js" main="@empty" id='demo-source'>
+import Component from "can/component/";
+import stache from "can/view/stache/";
+import $ from "jquery";
+
+can.Component.extend({
+	tag: "player-list",
+	template: can.view('player-list-stache'),
+	viewModel: {
+		players: new can.List([{name: "Justin"},{name: "Brian"}]),
+		editPlayer: function(player){
+			this.attr("editingPlayer", player);
+		},
+		removeEdit: function(){
+			this.removeAttr("editingPlayer");
+		},
+		isEditing: function(player){
+			return this.attr("editingPlayer") === player;
 		}
-	});
-	
-	can.Component.extend({
-		tag: "player-edit",
-		template: can.view('player-edit-stache'),
-		viewModel: {
-			close: function(){
-				this.dispatch("close");
-			}
+	}
+});
+
+can.Component.extend({
+	tag: "player-edit",
+	template: can.view('player-edit-stache'),
+	viewModel: {
+		close: function(){
+			this.dispatch("close");
 		}
-	});
-	
-    $("#out").html(stache("<player-list/>")({}));
+	}
+});
+
+$("#out").html(stache("<player-list/>")({}));
 	
 </script>
 </body>

--- a/view/bindings/doc/event.md
+++ b/view/bindings/doc/event.md
@@ -1,5 +1,5 @@
 @function can.view.bindings.event \(event\)
-@parent can.view.bindings
+@parent can.view.bindings 0
 
 @description Listen to events on elements or component view models.
 

--- a/view/bindings/doc/reference.md
+++ b/view/bindings/doc/reference.md
@@ -1,5 +1,5 @@
 @function can.view.bindings.reference *REFERENCE
-@parent can.view.bindings
+@parent can.view.bindings 4
 
 @description Export a viewModel into a template's references scope.
 

--- a/view/bindings/doc/to-child.html
+++ b/view/bindings/doc/to-child.html
@@ -1,0 +1,58 @@
+<script type='text/stache' can-autorender id='demo-html'>
+	<p>Alison: <player-scores {scores}="game.scoresForPlayer('Alison')"/></p>
+	<p>Jeff: <player-scores {scores}="game.scoresForPlayer('Jeff')"/></p>
+</script>
+
+<script src="../../../node_modules/steal/steal.js" main="@empty" id='demo-source'>
+import can from "can";
+import "can/view/autorender/autorender";
+import "can/view/bindings/bindings";
+import "can/view/stache/stache";
+import "can/map/define/";
+
+can.Component.extend({
+	tag: "player-scores",
+	template: can.stache('{{#each scores}} {{points}} {{/each}} = {{scores.sum}}')
+});
+
+var ScoreList = can.List.extend({
+	sum: function(){
+		var sum = 0;
+		this.each(function(score){
+			sum += score.attr("points");
+		});
+		return sum;
+	}
+});
+
+var Game = can.Map.extend({
+	define: {
+		scores: {
+			Type: ScoreList
+		}
+	},
+	scoresForPlayer: function(name){
+		return this.attr("scores").filter(function(score){
+			return score.attr("player") === name;
+		});
+	}
+});
+
+var game = new Game({
+	scores: [
+		{player: "Alison", points: 2},
+		{player: "Alison", points: 3},
+		{player: "Jeff", points: 5},
+		{player: "Jeff", points: 1},
+		{player: "Alison", points: 6},
+		{player: "Jeff", points: 1},
+	]
+});
+
+$("#demo-html").viewModel({
+	game: game
+});
+
+</script>
+
+

--- a/view/bindings/doc/to-child.md
+++ b/view/bindings/doc/to-child.md
@@ -1,5 +1,5 @@
 @function can.view.bindings.toChild {to-child}
-@parent can.view.bindings
+@parent can.view.bindings 1
 
 @description One-way bind a value in the parent scope to the [can.Component::viewModel viewModel].
 
@@ -39,5 +39,8 @@
 `{child-prop}="key"` is used to pass values from the scope to a component.  You can use CallExpressions like:
 
 ```
-<my-component {some-prop}="someMethod(arg)"/>
+<player-scores {scores}="game.scoresForPlayer('Alison')"/>
+<player-scores {scores}="game.scoresForPlayer('Jeff')"/>
 ```
+
+@demo can/view/bindings/doc/to-child.html

--- a/view/bindings/doc/to-parent.md
+++ b/view/bindings/doc/to-parent.md
@@ -1,5 +1,5 @@
 @function can.view.bindings.toParent {^to-parent}
-@parent can.view.bindings
+@parent can.view.bindings 2
 
 @description One-way bind a value in the current [can.Component::viewModel viewModel] to the parent scope.
 

--- a/view/bindings/doc/two-way.md
+++ b/view/bindings/doc/two-way.md
@@ -1,5 +1,5 @@
 @function can.view.bindings.twoWay {\(two-way\)}
-@parent can.view.bindings
+@parent can.view.bindings 3
 
 @description Two-way bind a value in the [can.Component::viewModel viewModel] or the element to the parent scope.
 

--- a/view/stache/expression.js
+++ b/view/stache/expression.js
@@ -465,19 +465,29 @@ steal("can/util",
 		}
 	});
 	
-	// converts "../foo" -> "../@foo", "foo" -> "@foo", ".foo" -> "@foo", "./foo" -> "./@foo"
+	// converts 
+	// - "../foo" -> "../@foo", 
+	// - "foo" -> "@foo", 
+	// - ".foo" -> "@foo", 
+	// - "./foo" -> "./@foo"
+	// - "foo.bar" -> "foo@bar"
+	var convertKeyToLookup = function(key){
+		var lastPath = key.lastIndexOf("./");
+		var lastDot = key.lastIndexOf(".");
+		if(lastDot > lastPath) {
+			return key.substr(0, lastDot)+"@"+key.substr(lastDot+1);
+		}
+		var firstNonPathCharIndex = lastPath === -1 ? 0 : lastPath+2;
+		var firstNonPathChar = key.charAt(firstNonPathCharIndex);
+		if(firstNonPathChar === "." || firstNonPathChar === "@" ) {
+			return key.substr(0, firstNonPathCharIndex)+"@"+key.substr(firstNonPathCharIndex+1);
+		} else {
+			return key.substr(0, firstNonPathCharIndex)+"@"+key.substr(firstNonPathCharIndex);
+		}
+	};
 	var convertToAtLookup = function(ast){
 		if(ast.type === "Lookup") {
-			var key = ast.key;
-			var lastPath = key.lastIndexOf("./");
-			var firstNonPathCharIndex = lastPath === -1 ? 0 : lastPath+2;
-			var firstNonPathChar = key.charAt(firstNonPathCharIndex);
-			if(firstNonPathChar === "." || firstNonPathChar === "@" ) {
-				key = key.substr(0, firstNonPathCharIndex)+"@"+key.substr(firstNonPathCharIndex+1);
-			} else {
-				key = key.substr(0, firstNonPathCharIndex)+"@"+key.substr(firstNonPathCharIndex);
-			}
-			ast.key = key;
+			ast.key = convertKeyToLookup(ast.key);
 		}
 		return ast;
 	};
@@ -499,6 +509,7 @@ steal("can/util",
 	};
 	
 	var expression = {
+		convertKeyToLookup: convertKeyToLookup,
 		Literal: Literal,
 		Lookup: Lookup,
 		ScopeLookup: ScopeLookup,

--- a/view/stache/expression_test.js
+++ b/view/stache/expression_test.js
@@ -276,4 +276,13 @@ steal("./expression.js", "steal-qunit", function(){
 		equal( res(), 12);
 	});
 	
+	test("convertKeyToLookup", function(){
+		
+		equal( expression.convertKeyToLookup("../foo"), "../@foo" );
+		equal( expression.convertKeyToLookup("foo"), "@foo" );
+		equal( expression.convertKeyToLookup(".foo"), "@foo" );
+		equal( expression.convertKeyToLookup("./foo"), "./@foo" );
+		equal( expression.convertKeyToLookup("foo.bar"), "foo@bar" );
+		
+	});
 });


### PR DESCRIPTION
If you had a binding like:

```
<component {prop}="foo.bar()"/>
```

This wouldn't work.  The fix was to make sure this turns into "foo@bar".