### PR TITLE
Improvements to compute, map, and live-binding performance

### DIFF
--- a/component/component_test.js
+++ b/component/component_test.js
@@ -1705,19 +1705,12 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 		});
 
 		asyncTest('<content> node list cleans up properly, directly nested (#1625, #1627)', function() {
-			var items = [];
-			for (var i = 0; i < 2; i++) {
-				items.push({
-					name: 'test ' + i,
-					parentAttrInContent: 'test ' + i
-				});
-			}
 
 			can.Component.extend({
 				tag: 'parent-component',
 				template: can.stache('{{#items}}<child-component>{{parentAttrInContent}}</child-component>{{/items}}'),
 				scope: {
-					items: items
+					items: [{parentAttrInContent: 0},{parentAttrInContent: 1} ]
 				}
 			});
 
@@ -1729,7 +1722,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 				}
 			});
 
-			can.append(can.$("#qunit-fixture"), can.stache('<parent-component></parent-component>')());
+			can.append(can.$("#qunit-fixture"), can.stache('<parent-component/>')());
 
 			var old = can.unbindAndTeardown;
 			var count = 0;
@@ -1744,7 +1737,7 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can", "can/map/define", 
 
 			// Dispatches async
 			setTimeout(function() {
-				equal(count, 2, '2 items unbound');
+				equal(count, 4, '2 items unbound, but unbinding the temporary unbind and the actual unbind');
 				can.unbindAndTeardown = old;
 
 				start();

--- a/compute/compute_test.js
+++ b/compute/compute_test.js
@@ -30,7 +30,8 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 
 	test('can.compute.truthy', function () {
 		var result = 0;
-		var num = can.compute(3);
+		var numValue;
+		var num = can.compute(numValue = 3);
 		var truthy = can.compute.truthy(num);
 		var tester = can.compute(function () {
 			if (truthy()) {
@@ -49,10 +50,10 @@ steal("can/compute", "can/test", "can/map", "steal-qunit", function () {
 			}
 		});
 		equal(tester(), 1, 'on bind, we call tester once');
-		num(2);
-		num(1);
-		num(0);
-		num(-1);
+		num(numValue = 2);
+		num(numValue = 1);
+		num(numValue = 0);
+		num(numValue = -1);
 	});
 	test('a binding compute does not double read', function () {
 		var sourceAge = 30,

--- a/compute/get_value_and_bind.js
+++ b/compute/get_value_and_bind.js
@@ -99,13 +99,13 @@ steal("can/util", function(can){
 			if(top.traps) {
 				top.traps.push({obj: obj, event: evStr, name: name});
 			} 
-			else if(!top.ignore && !(name in top.newObserved)) {
+			else if(!top.ignore && !top.newObserved[name]) {
 				top.newObserved[name] = {
 					obj: obj,
 					event: evStr
 				};
 				
-				if(!(name in top.oldObserved)) {
+				if(!top.oldObserved[name]) {
 					obj.bind(evStr, top.onchanged);
 				}
 				top.oldObserved[name] = null;
@@ -136,10 +136,10 @@ steal("can/util", function(can){
 				var trap = observes[i],
 					name = trap.name;
 				
-				if(!(name in top.newObserved)) {
+				if(!top.newObserved[name]) {
 					top.newObserved[name] = trap;
 					
-					if(!(name in top.oldObserved)) {
+					if(!top.oldObserved[name]) {
 						trap.obj.bind(trap.event, top.onchanged);
 					}
 					top.oldObserved[name] = null;

--- a/compute/get_value_and_bind.js
+++ b/compute/get_value_and_bind.js
@@ -90,14 +90,14 @@ steal("can/util", function(can){
 	// ## can.__observe
 	// Indicates that an observable is being read.  
 	// Updates the top of the stack with the observable being read.
-	var observe = can.__observe = function (obj, event) {
+	can.__observe = function (obj, event) {
 		var top = observedInfoStack[observedInfoStack.length-1];
 		if (top) {
 			var evStr = event + "",
 				name = obj._cid + '|' + evStr;
 			if(top.traps) {
 				top.traps.push({obj: obj, event: evStr, name: name});
-			} 
+			}
 			else if(!top.ignore && !top.newObserved[name]) {
 				top.newObserved[name] = {
 					obj: obj,

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -381,7 +381,7 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 	var updateOnChange = function(compute, newValue, oldValue, batchNum){
 		// Only trigger event when value has changed
 		if (newValue !== oldValue) {
-			can.batch.trigger(compute, batchNum ? {type: "change", batchNum: batchNum} : 'change', [
+			can.batch.trigger(compute, {type: "change", batchNum: batchNum}, [
 				newValue,
 				oldValue
 			]);
@@ -394,7 +394,7 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 	var setupComputeHandlers = function(compute, func, context) {
 
 		// The last observeInfo object returned by getValueAndBind.
-		var readInfo,
+		var readInfo = {},
 			// The last batch number seen.
 			batchNum,
 			// A function that gets called whenever any observed observables change.
@@ -404,15 +404,14 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 				// and the batchNum has changed.
 				
 				// It's possible that something we are listening to changed before we even get readInfo
-				if (readInfo && 
-					readInfo.ready &&
+				if (readInfo.ready &&
 					compute.bound &&
 					(ev.batchNum === undefined || ev.batchNum !== batchNum) ) {
 						
 					// Keep the old value.
 					var oldValue = readInfo.value;
 					// Get the new value and register this event handler to any new observables.
-					readInfo = getValueAndBind(func, context, readInfo, onchanged);
+					getValueAndBind(func, context, readInfo, onchanged);
 					// Update the compute with the new value.
 					compute.updater(readInfo.value, oldValue, ev.batchNum);
 					batchNum = ev.batchNum;
@@ -422,7 +421,7 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 		return {
 			// Call `onchanged` when any source observables change.
 			on: function(){
-				readInfo = getValueAndBind(func, context, {}, onchanged);
+				getValueAndBind(func, context, readInfo, onchanged);
 				compute.value = readInfo.value;
 				compute.hasDependencies = !can.isEmptyObject(readInfo.newObserved);
 			},

--- a/compute/proto_compute.js
+++ b/compute/proto_compute.js
@@ -86,8 +86,8 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 		// ## Setup getter / setter functional computes
 		// Uses the function as both a getter and setter.
 		_setupGetterSetterFn: function(getterSetter, context, eventName) {
-			this._set = can.proxy(getterSetter, context);
-			this._get = can.proxy(getterSetter, context);
+			this._set = context ? can.proxy(getterSetter, context) : getterSetter;
+			this._get = context ? can.proxy(getterSetter, context) : getterSetter;
 			this._canObserve = eventName === false ? false : true;
 			// The helper provides the on and off methods that use `getValueAndBind`.
 			var handlers = setupComputeHandlers(this, getterSetter, context || this);
@@ -154,8 +154,8 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 			
 			this.value = initialValue;
 			
-			this._set = settings.set ? can.proxy(settings.set, settings) : this._set;
-			this._get = settings.get ? can.proxy(settings.get, settings) : this._get;
+			this._set = settings.set || this._set;
+			this._get = settings.get || this._get;
 
 			// This allows updater to be called without any arguments.
 			// selfUpdater flag can be set by things that want to call updater themselves.
@@ -437,12 +437,13 @@ steal('can/util', 'can/util/bind', 'can/compute/read.js','can/compute/get_value_
 	// ### temporarilyBind
 	// Binds computes for a moment to cache their value and prevent re-calculating it.
 	can.Compute.temporarilyBind = function (compute) {
-		compute.bind('change', can.k);
+		var computeInstance = compute.computeInstance || compute;
+		computeInstance.bind('change', can.k);
 		if (!computes) {
 			computes = [];
 			setTimeout(unbindComputes, 10);
 		}
-		computes.push(compute);
+		computes.push(computeInstance);
 	};
 	
 	// A list of temporarily bound computes

--- a/event/event.js
+++ b/event/event.js
@@ -236,18 +236,26 @@ steal('can/util/can.js', function (can) {
 		if (!events) {
 			return;
 		}
-
+		var eventName;
 		// Initialize the event object
 		if (typeof event === 'string') {
+			eventName = event;
 			event = {
 				type: event
 			};
+		} else {
+			eventName = event.type;
+		}
+		
+		var handlers = events[eventName];
+		if(!handlers) {
+			return;
+		} else {
+			handlers = handlers.slice(0);
 		}
 
 		// Grab event listeners
-		var eventName = event.type,
-			handlers = (events[eventName] || []).slice(0),
-			passed = [event];
+		var passed = [event];
 		
 		// Execute handlers listening for this event.
 		if(args) {

--- a/event/event.js
+++ b/event/event.js
@@ -247,6 +247,7 @@ steal('can/util/can.js', function (can) {
 			eventName = event.type;
 		}
 		
+		// Grab event listeners
 		var handlers = events[eventName];
 		if(!handlers) {
 			return;
@@ -254,7 +255,7 @@ steal('can/util/can.js', function (can) {
 			handlers = handlers.slice(0);
 		}
 
-		// Grab event listeners
+		
 		var passed = [event];
 		
 		// Execute handlers listening for this event.

--- a/list/list.js
+++ b/list/list.js
@@ -359,7 +359,7 @@ steal("can/util", "can/map", "can/map/bubble.js","can/map/map_helpers.js",functi
 						curVal.attr(newVal, remove);
 						//changed from a coercion to an explicit
 					} else if (curVal !== newVal) {
-						this._set(prop, newVal);
+						this._set(prop+"", newVal);
 					} else {
 
 					}

--- a/map/map.js
+++ b/map/map.js
@@ -201,10 +201,10 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 				}
 				else if (arguments.length === 1) {
 					// Get a single attribute.
-					return this._get(attr);
+					return this._get(attr+"");
 				} else {
 					// Set an attribute.
-					this._set(attr, val);
+					this._set(attr+"", val);
 					return this;
 				}
 			},
@@ -216,7 +216,6 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// To read the actual values, `_get` calls
 			// `___get`.
 			_get: function (attr) {
-				attr = attr+"";
 				var dotIndex = attr.indexOf('.');
 
 				if( dotIndex >= 0 ) {
@@ -276,11 +275,11 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// If the map is initializing, the current value does not need to be
 			// read because no change events are dispatched anyway.
 			_set: function (attr, value, keepKey) {
-				attr = ""+attr;
+
 				var dotIndex = attr.indexOf('.'),
 					current;
 
-				if(!keepKey && dotIndex >= 0){
+				if(dotIndex >= 0 && !keepKey){
 					var first = attr.substr(0, dotIndex),
 						second = attr.substr(dotIndex+1);
 
@@ -313,7 +312,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// list or map instance is used.
 			__type: function(value, prop){
 
-				if (!( value instanceof can.Map) && mapHelpers.canMakeObserve(value)  ) {
+				if (typeof value === "object" && !( value instanceof can.Map) && mapHelpers.canMakeObserve(value)  ) {
 
 					var cached = mapHelpers.getMapFromObject(value);
 					if(cached) {

--- a/map/map.js
+++ b/map/map.js
@@ -216,7 +216,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 			// To read the actual values, `_get` calls
 			// `___get`.
 			_get: function (attr) {
-				attr = ""+attr;
+				attr = attr+"";
 				var dotIndex = attr.indexOf('.');
 
 				if( dotIndex >= 0 ) {

--- a/map/map.js
+++ b/map/map.js
@@ -342,7 +342,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 						.hasOwnProperty(prop) ? "set" : "add";
 
 					// Set the value on `_data` and set up bubbling.
-					this.___set(prop, bubble.set(this, prop, value, current) );
+					this.___set(prop, typeof value === "object" ? bubble.set(this, prop, value, current) : value );
 
 					// Computed properties change events are already forwarded.
 					if(!this._computedAttrs[prop]) {
@@ -351,7 +351,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 
 
 					// Stop bubbling old nested maps.
-					if (current) {
+					if (typeof current === "object") {
 						bubble.teardownFromParent(this, current);
 					}
 				}

--- a/observe/observe_test.js
+++ b/observe/observe_test.js
@@ -1044,6 +1044,8 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", "steal-qunit
 		}]);
 		equal(2, computedCount, 'only one compute');
 	});
+	
+	
 	test('Generate computes from Observes with can.Map.prototype.compute (#203)', 6, function () {
 		var obs = new can.Map({
 			test: 'testvalue'
@@ -1051,8 +1053,11 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", "steal-qunit
 		var compute = obs.compute('test');
 		ok(compute.isComputed, '`test` is computed');
 		equal(compute(), 'testvalue', 'Value is as expected');
+		
 		obs.attr('test', 'observeValue');
+		
 		equal(compute(), 'observeValue', 'Value is as expected');
+		
 		compute.bind('change', function (ev, newVal) {
 			equal(newVal, 'computeValue', 'new value from compute');
 		});
@@ -1060,8 +1065,11 @@ steal('can/util', "can/observe", 'can/map', 'can/list', "can/test", "steal-qunit
 			equal(newVal, 'computeValue', 'Got new value from compute');
 		});
 		compute('computeValue');
+		
 		equal(compute(), 'computeValue', 'Got updated value');
 	});
+	
+	
 	test('compute of computes', function () {
 		expect(2);
 		var suggestedSearch = can.compute(null),

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"github": "https://github.com/bitovi/canjs"
 	},
 	"dependencies": {
-		"can-simple-dom": "^0.2.16"
+		"can-simple-dom": "^0.2.19"
 	},
 	"peerDependencies": {
 		"jquery": ">=1.9.0 <3.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"github": "https://github.com/bitovi/canjs"
 	},
 	"dependencies": {
-		"can-simple-dom": "^0.2.19"
+		"can-simple-dom": "^0.2.20"
 	},
 	"peerDependencies": {
 		"jquery": ">=1.9.0 <3.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"github": "https://github.com/bitovi/canjs"
 	},
 	"dependencies": {
-		"can-simple-dom": "^0.2.8"
+		"can-simple-dom": "^0.2.16"
 	},
 	"peerDependencies": {
 		"jquery": ">=1.9.0 <3.0.0"

--- a/test/templates/__configuration__-dist.html.ejs
+++ b/test/templates/__configuration__-dist.html.ejs
@@ -33,9 +33,15 @@
 <script type="text/javascript" src="bower_components/qunit/qunit/qunit.js"></script>
 <script type="text/javascript">
 	QUnit.config.autostart = false;
+	var MODULE_ALIAS = module;
+    module = undefined;
 </script>
 
 <script type="text/javascript" src="node_modules/can-simple-dom/dist/global/can-simple-dom.js"></script>
+<script type="text/javascript">
+    module = MODULE_ALIAS;
+</script>
+
 <script type="text/javascript" src="<%= configuration.library %>"></script>
 <script type="text/javascript" src="dist/<%= dist.replace('-2', '') %>.js"></script>
 <% modules.forEach(function(module) { %><% if(!module.isDefault) { %><script type="text/javascript" src="dist/<%= module %>.js"></script><% } %><% }); %>

--- a/util/attr/attr.js
+++ b/util/attr/attr.js
@@ -93,16 +93,19 @@ steal("can/util/can.js", function (can) {
 				
 				attrName = attrName.toLowerCase();
 				var oldValue;
-				// In order to later trigger an event we need to compare the new value to the old value, so here we go ahead and retrieve the old value for browsers that don't have native MutationObservers.
+				// In order to later trigger an event we need to compare the new value to the old value, 
+				// so here we go ahead and retrieve the old value for browsers that don't have native MutationObservers.
 				if (!usingMutationObserver) {
 					oldValue = attr.get(el, attrName);
 				}
 
-				var tagName = el.nodeName.toString().toLowerCase(),
-					prop = attr.map[attrName],
+				var prop = attr.map[attrName],
 					newValue;
 
-				// Using the property of `attr.map`, go through and check if the property is a function, and if so call it. Then check if the property is `true`, and if so set the value to `true`, also making sure to set `defaultChecked` to `true` for elements of `attr.defaultValue`. We always set the value to true because for these boolean properties, setting them to false would be the same as removing the attribute.
+				// Using the property of `attr.map`, go through and check if the property is a function, and if so call it. 
+				// Then check if the property is `true`, and if so set the value to `true`, also making sure 
+				// to set `defaultChecked` to `true` for elements of `attr.defaultValue`. We always set the value to true 
+				// because for these boolean properties, setting them to false would be the same as removing the attribute.
 				//
 				// For all other attributes use `setAttribute` to set the new value.
 				if (typeof prop === "function") {
@@ -111,7 +114,7 @@ steal("can/util/can.js", function (can) {
 					newValue = el[attrName] = true;
 
 					if (attrName === "checked" && el.type === "radio") {
-						if (can.inArray(tagName, attr.defaultValue) >= 0) {
+						if (can.inArray((el.nodeName+"").toLowerCase(), attr.defaultValue) >= 0) {
 							el.defaultChecked = true;
 						}
 					}
@@ -121,7 +124,7 @@ steal("can/util/can.js", function (can) {
 					if (el[prop] !== val) {
 						el[prop] = val;
 					}
-					if (prop === "value" && can.inArray(tagName, attr.defaultValue) >= 0) {
+					if (prop === "value" && can.inArray((el.nodeName+"").toLowerCase(), attr.defaultValue) >= 0) {
 						el.defaultValue = val;
 					}
 				} else {

--- a/util/attr/attr.js
+++ b/util/attr/attr.js
@@ -62,9 +62,18 @@ steal("can/util/can.js", function (can) {
 						return val;
 					}
 				},
-				style: function (el, val) {
-					return el.style && "cssText" in el.style ? el.style.cssText = val || "" : el.setAttribute("style", val);
-				}
+				style: (function () {
+					var el = can.global.document && document.createElement('div');
+					if ( el && el.style && ("cssText" in el.style) ) {
+						return function (el, val) {
+							return el.style.cssText = (val || "");
+						};
+					} else {
+						return function (el, val) {
+							return el.setAttribute("style", val);
+						};
+					}
+				})()
 			},
 			// These are elements whos default value we should set.
 			defaultValue: ["input", "textarea"],

--- a/util/batch/batch.js
+++ b/util/batch/batch.js
@@ -176,9 +176,8 @@ steal('can/util/can.js', function (can) {
 					return;
 				}
 
-				currentBatchEvents = batchEvents.slice(0);
-
-				currentBatchCallbacks = stopCallbacks.slice(0);
+				currentBatchEvents = batchEvents;
+				currentBatchCallbacks = stopCallbacks;
 				var i, len;
 				batchEvents = [];
 				stopCallbacks = [];
@@ -189,7 +188,6 @@ steal('can/util/can.js', function (can) {
 					can.batch.start();
 				}
 				for(i = 0; i < currentBatchEvents.length; i++) {
-					currentBatchEvents[i][1][0].orderNum = i;
 					can.dispatch.apply(currentBatchEvents[i][0],currentBatchEvents[i][1]);
 				}
 				currentBatchEvents = null;
@@ -243,11 +241,11 @@ steal('can/util/can.js', function (can) {
 		},
 		afterPreviousEvents: function(handler){
 			if(currentBatchEvents) {
-				var obj = {};
-				can.bind.call(obj,"ready", handler);
+				// This basically creates an object with an event handler that
+				// will be dispatched.
+				var obj = {__bindEvents: {ready: [{handler: handler}]}};
 				currentBatchEvents.push([
-					obj,
-					[{type: "ready"}, []]
+					obj, [{type: "ready"}, []]
 				]);
 			} else {
 				handler({});

--- a/view/callbacks/callbacks.js
+++ b/view/callbacks/callbacks.js
@@ -73,9 +73,7 @@ steal("can/util", "can/view",function(can){
 				res;
 				
 			if(tagCallback) {
-				var reads = can.__clearObserved();
-				res = tagCallback(el, tagData);
-				can.__setObserved(reads);
+				res = can.__notObserve(tagCallback)(el, tagData);
 			} else {
 				res = scope;
 			}

--- a/view/live/live.js
+++ b/view/live/live.js
@@ -63,9 +63,9 @@ steal('can/util',
 		// operate on a compute
 		listen = function (el, compute, change) {
 			return setup(el, function () {
-				compute.bind('change', change);
+				compute.computeInstance.bind('change', change);
 			}, function (data) {
-				compute.unbind('change', change);
+				compute.computeInstance.unbind('change', change);
 				if (data.nodeList) {
 					nodeLists.unregister(data.nodeList);
 				}

--- a/view/mustache/mustache.js
+++ b/view/mustache/mustache.js
@@ -1736,16 +1736,17 @@ steal('can/util',
 			// If there is a "partial" property and there is not
 			// an already-cached partial, we use the value of the 
 			// property to look up the partial
-
+			
 			// if this partial is not cached ...
 			if (!can.view.cached[partial]) {
 				// we don't want to bind to changes so clear and restore reading
-				var reads = can.__clearReading();
-				var scopePartialName = scope.attr(partial);
-				if (scopePartialName) {
-					partial = scopePartialName;
-				}
-				can.__setReading(reads);
+				can.__notObserve(function(){
+					var scopePartialName = scope.attr(partial);
+					if (scopePartialName) {
+						partial = scopePartialName;
+					}
+				})();
+				
 			}
 
 			// Call into `can.view.render` passing the

--- a/view/mustache/mustache_test.js
+++ b/view/mustache/mustache_test.js
@@ -26,7 +26,7 @@ steal("can/model", "can/view/mustache", "can/test", "can/view/mustache/spec/spec
 				"{{/animals}}</ul>";
 
 		}
-	})
+	});
 
 	// Override expected spec result for whitespace only issues
 	var override = {

--- a/view/scope/compute_data.js
+++ b/view/scope/compute_data.js
@@ -18,20 +18,15 @@ steal("can/util","can/compute","can/compute/get_value_and_bind.js",function(can,
 	};
 	
 	var getValueAndBindScopeRead = function(scopeRead, scopeReadChanged){
-		return getValueAndBind(scopeRead, null, {observed: {}}, scopeReadChanged);
+		return getValueAndBind(scopeRead, null, {}, scopeReadChanged);
 	};
-	var unbindScopeRead = function(readInfo, scopeReadChanged){
-		for (var name in readInfo.observed) {
-			var ob = readInfo.observed[name];
-			ob.obj.unbind(ob.event, scopeReadChanged);
-		}
-	};
+	var unbindScopeRead = getValueAndBind.unbindReadInfo;
 	var getValueAndBindSinglePropertyRead = function(computeData, singlePropertyReadChanged){
 		var target = computeData.root,
 			prop = computeData.reads[0].key;
 		target.bind(prop, singlePropertyReadChanged);
 		// something: true is just a dummy value so we know something is observed
-		return {value: computeData.initialValue, observed: {something: true}};
+		return {value: computeData.initialValue, newObserved: {something: true}};
 	};
 	var unbindSinglePropertyRead = function(computeData, singlePropertyReadChanged){
 		computeData.root.unbind(computeData.reads[0].key, singlePropertyReadChanged);
@@ -137,7 +132,7 @@ steal("can/util","can/compute","can/compute/get_value_and_bind.js",function(can,
 					}
 					// TODO deal with this right
 					compute.computeInstance.value = readInfo.value;
-					compute.computeInstance.hasDependencies = !can.isEmptyObject(readInfo.observed);
+					compute.computeInstance.hasDependencies = !can.isEmptyObject(readInfo.newObserved);
 				},
 				off: function(){
 					if(isFastPathBound) {

--- a/view/scope/scope.js
+++ b/view/scope/scope.js
@@ -287,10 +287,14 @@ steal(
 							if(refInstance) {
 								searchedRefsScope = true;
 							}
-
+							var getObserves = can.__trapObserves();
+							
 							var data = can.compute.read(context, names, readOptions);
+							
+							var observes = getObserves();
 							// **Key was found**, return value and location data
 							if (data.value !== undefined) {
+								can.__observes(observes);
 								return {
 									scope: scope,
 									rootObserve: currentObserve,
@@ -299,7 +303,7 @@ steal(
 								};
 							} else {
 								// save all old readings before we try the next scope
-								undefinedObserves.push( can.__clearObserved() );
+								undefinedObserves.push.apply(undefinedObserves, observes);
 							}
 						}
 
@@ -314,12 +318,7 @@ steal(
 					// **Key was not found**, return undefined for the value.
 					// Make sure we listen to everything we checked for when the value becomes defined.
 					// Once it becomes defined, we won't have to listen to so many things.
-					var len = undefinedObserves.length;
-					if (len) {
-						for(var i = 0; i < len; i++) {
-							can.__addObserved(undefinedObserves[i]);
-						}
-					}
+					can.__observes(undefinedObserves);
 					return {
 						setRoot: currentSetObserve,
 						reads: currentSetReads,

--- a/view/stache/benchmark/spinning_circle_benchmark.js
+++ b/view/stache/benchmark/spinning_circle_benchmark.js
@@ -62,9 +62,15 @@ steal('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b)
 			},
 			teardown: function(){
 				$(div).remove();
+			},
+			onStart: function(){
+				console.profile("init")
+			},
+			onComplete: function(){
+				console.profileEnd("init")
 			}
 		});
-	
+	/*
 	suite.add(
 		"initial render",
 		function () {
@@ -125,6 +131,6 @@ steal('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b)
 			onComplete: function(){
 				//console.profileEnd("init")
 			}
-		});
+		});*/
 	/* jshint ignore:end */
 });

--- a/view/stache/benchmark/spinning_circle_benchmark.js
+++ b/view/stache/benchmark/spinning_circle_benchmark.js
@@ -1,7 +1,4 @@
-var can = require('can/util/'),
-	stache = require('can/')
-
-('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b) {
+steal('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b) {
 
 	/* jshint ignore:start */
 	var suite = b.suite("can/view/stache spinning circle");

--- a/view/stache/benchmark/spinning_circle_benchmark.js
+++ b/view/stache/benchmark/spinning_circle_benchmark.js
@@ -3,6 +3,7 @@ steal('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b)
 	/* jshint ignore:start */
 	var suite = b.suite("can/view/stache spinning circle");
 	
+	
 	suite.add(
 		"basics",
 		function () {
@@ -67,6 +68,7 @@ steal('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b)
 	suite.add(
 		"initial render",
 		function () {
+			
 			var frag = template({boxes: boxes});
 			window.frag = frag;
 		},
@@ -112,10 +114,16 @@ steal('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b)
 					boxes.push( box );
 				}
 				
-				
 			},
 			teardown: function(){
+				
 				window.frag = null;
+			},
+			onStart: function(){
+				//console.profile("init")
+			},
+			onComplete: function(){
+				//console.profileEnd("init")
 			}
 		});
 	/* jshint ignore:end */

--- a/view/stache/benchmark/spinning_circle_benchmark.js
+++ b/view/stache/benchmark/spinning_circle_benchmark.js
@@ -1,4 +1,7 @@
-steal('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b) {
+var can = require('can/util/'),
+	stache = require('can/')
+
+('can/util','can/view/stache', 'steal-benchmark', function (can, stache, b) {
 
 	/* jshint ignore:start */
 	b.suite("can/view/stache spinning circle").add(

--- a/view/stache/initial_render_benchmark.html
+++ b/view/stache/initial_render_benchmark.html
@@ -44,7 +44,7 @@
 <button id='start'>Start</button>
 <button id='stop'>Stop</button>
 <div id='timing'></div>
-<script type="text/javascript" src="../../lib/steal/steal.js"></script>
+<script type="text/javascript" src="../../node_modules/steal/steal.js"></script>
 <script type="text/javascript">
 
 	steal("can/view/stache", function(stache){
@@ -80,8 +80,10 @@
 				items: items
 			});
 			console.log(new Date() - d);
-			document.body.appendChild(t);
+			$("body").append("<p>"+(new Date() - d)+"</p>");
 		};
+		
+		$("#start").click(go);
 	});
 	
 	

--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -309,12 +309,20 @@ steal("can/util",
 				// parent expresions.  If this value changes, the parent expressions should
 				// not re-evaluate. We prevent that by making sure this compute is ignored by
 				// everyone else.
-				var compute = can.compute(evaluator, null, false);
+				//var compute = can.compute(evaluator, null, false);
+				var gotCompute = evaluator.isComputed,
+					compute;
+				if(gotCompute) {
+					compute = evaluator;
+				} else {
+					compute = can.compute(evaluator, null, false);
+				}
+				
+				
 				// Bind on the compute to set the cached value. This helps performance
 				// so live binding can read a cached value instead of re-calculating.
-				compute.bind("change", can.k);
+				compute.computeInstance.bind("change", can.k);
 				var value = compute();
-				
 
 				// If value is a function, it's a helper that returned a function.
 				if(typeof value === "function") {
@@ -328,7 +336,7 @@ steal("can/util",
 
 				}
 				// If the compute has observable dependencies, setup live binding.
-				else if( compute.computeInstance.hasDependencies ) {
+				else if(gotCompute || compute.computeInstance.hasDependencies ) {
 
 					// Depending on where the template is, setup live-binding differently.
 					if(state.attr) {
@@ -361,7 +369,7 @@ steal("can/util",
 					}
 				}
 				// Unbind the compute.
-				compute.unbind("change", can.k);
+				compute.computeInstance.unbind("change", can.k);
 			};
 		},
 		// ## mustacheCore.splitModeFromExpression

--- a/view/stache/mustache_core.js
+++ b/view/stache/mustache_core.js
@@ -324,9 +324,7 @@ steal("can/util",
 					// we hide any observables read in the function by saving any observables that
 					// have been read and then setting them back which overwrites any `can.__observe` calls
 					// performed in value.
-					var old = can.__clearObserved();
-					value(this);
-					can.__setObserved(old);
+					can.__notObserve(value)(this);
 
 				}
 				// If the compute has observable dependencies, setup live binding.

--- a/view/stache/text_section.js
+++ b/view/stache/text_section.js
@@ -3,8 +3,7 @@ steal("can/util", "can/view/live","./utils.js", "./live_attr.js", function(can, 
 	
 	var TextSectionBuilder = function(){
 		this.stack = [new TextSection()];
-	},
-		emptyHandler = function(){};
+	};
 	
 	can.extend(TextSectionBuilder.prototype,utils.mixins);
 	
@@ -32,9 +31,9 @@ steal("can/util", "can/view/live","./utils.js", "./live_attr.js", function(can, 
 				
 				var compute = can.compute(function(){
 					return renderer(scope, options);
-				}, this, false);
+				}, null, false);
 				
-				compute.bind("change", emptyHandler);
+				compute.computeInstance.bind("change", can.k);
 				var value = compute();
 				
 				if( compute.computeInstance.hasDependencies ) {
@@ -43,7 +42,7 @@ steal("can/util", "can/view/live","./utils.js", "./live_attr.js", function(can, 
 					} else {
 						liveStache.attributes(this, compute, scope, options);
 					}
-					compute.unbind("change", emptyHandler);
+					compute.computeInstance.unbind("change", can.k);
 				} else {
 					if(state.attr) {
 						can.attr.set(this, state.attr, value);

--- a/view/stache/visual_benchmark.html
+++ b/view/stache/visual_benchmark.html
@@ -110,7 +110,7 @@
 		$("#start").click(function(){
 			 loopCount = 0;
    			 totalTime = 0;
-   			 console.profile("loops");
+   			 //console.profile("loops");
    			 benchmarkLoop(run);
 		});
 		
@@ -133,7 +133,7 @@
 			    	benchmarkLoop(fn);
 			    },1);
 		    } else {
-		    	console.profileEnd("loops");
+		    	//console.profileEnd("loops");
 		    }
 		   
 		};

--- a/view/stache/visual_benchmark.html
+++ b/view/stache/visual_benchmark.html
@@ -110,6 +110,7 @@
 		$("#start").click(function(){
 			 loopCount = 0;
    			 totalTime = 0;
+   			 console.profile("loops");
    			 benchmarkLoop(run);
 		});
 		
@@ -124,13 +125,15 @@
 		    var endDate = new Date();
 		    totalTime += endDate - startDate;
 		    loopCount++;
-		    if (loopCount % 20 === 0) {
+		    if (loopCount % 100 === 0) {
 		        $('#timing').text('Performed ' + loopCount + ' iterations in ' + totalTime + ' ms (average ' + (totalTime / loopCount).toFixed(2) + ' ms per loop).');
 		    }
 		    if(loopCount < 1000) {
 		    	timeout = setTimeout(function(){
 			    	benchmarkLoop(fn);
 			    },1);
+		    } else {
+		    	console.profileEnd("loops");
 		    }
 		   
 		};

--- a/view/view.js
+++ b/view/view.js
@@ -600,7 +600,7 @@ steal('can/util', function (can) {
 
 			// See if we got passed any deferreds.
 			var deferreds = getDeferreds(data);
-			var reading, deferred, dataCopy, async, response;
+			var deferred, dataCopy, async, response;
 			if (deferreds.length) {
 				// Does data contain any deferreds?
 				// The deferred that resolves into the rendered content...
@@ -648,18 +648,13 @@ steal('can/util', function (can) {
 				// Return the deferred...
 				return deferred;
 			} else {
-				// get is called async but in
-				// ff will be async so we need to temporarily reset
-				reading = can.__clearReading();
 
 				// If there's a `callback` function
 				async = isFunction(callback);
-				// Get the `view` type
-				deferred = getRenderer(view, async);
-
-				if (reading) {
-					can.__setReading(reading);
-				}
+				
+				// get is called async but in
+				// ff will be async so we need to temporarily reset
+				deferred = can.__notObserve(getRenderer)(view, async);
 
 				// If we are `async`...
 				if (async) {


### PR DESCRIPTION
This makes several parts of canjs faster, dropping the spinning circle example from `6.64` ms in minor to `4.42` ms.  The end result will be about 30% faster improvement from `2.2` to `2.3`.

Their were several improvements:

- make can.__observe setup binding immediately.
- change getValueAndBind to use an object that contains a lot of stateful information instead of taking multiple arguments.
- making can.Map more quickly decide to do a type conversion or setup / teardown bubbling.
- removing some unnecessary proxy calls
- avoiding can.compute.bind in favor of a computeInstance's bind
- removing feature detection from within style and only doing it once
- making `afterPreviousEvents` not actually bind and dispatch to an object ... instead just create the right type of object.

