### PR TITLE
Allows stache to call methods on can.Maps instead of passing functions.

### DIFF
--- a/compute/read.js
+++ b/compute/read.js
@@ -6,6 +6,7 @@ steal("can/util", function(can){
 	// actually check
 	// - isArgument - should be renamed to something like "onLastPropertyReadReturnFunctionInsteadOfCallingIt".
 	//   This is used to make a compute out of that function if necessary.
+	// - callMethodsOnObservables - this is an overwrite ... so normal methods won't be called, but observable ones will.
 	// - executeAnonymousFunctions - call a function if it's found, defaults to true
 	// - proxyMethods - if the last read is a method, return a function so `this` will be correct.
 	// - args - arguments to call functions with.
@@ -126,7 +127,11 @@ steal("can/util", function(can){
 		read: function(value, i, reads, options, state, prev){
 			if( isAt(i, reads) ) {
 				return i === reads.length ? can.proxy(value, prev) : value;
-			}else if ( options.isArgument && i === reads.length) {
+			}
+			else if(options.callMethodsOnObservables && can.isMapLike(prev)) {
+				return value.apply(prev, options.args || []);
+			}
+			else if ( options.isArgument && i === reads.length ) {
 				return options.proxyMethods !== false ? can.proxy(value, prev) : value;
 			}
 			return value.apply(prev, options.args || []);

--- a/view/stache/expression.js
+++ b/view/stache/expression.js
@@ -211,7 +211,7 @@ steal("can/util",
 		Lookup.apply(this, arguments);
 	};
 	HelperScopeLookup.prototype.value = function(scope, helperOptions){
-		return lookupValue(this.key, scope, helperOptions, {isArgument: true, args: [scope.attr('.'), scope]}).value;
+		return lookupValue(this.key, scope, helperOptions, {callMethodsOnObservables: true, isArgument: true, args: [scope.attr('.'), scope]}).value;
 	};
 	
 	var Helper = function(methodExpression, argExpressions, hashExpressions){

--- a/view/stache/stache_test.js
+++ b/view/stache/stache_test.js
@@ -4487,6 +4487,43 @@ steal("can-simple-dom", "can/util/vdom/build_fragment","can/view/stache", "can/v
 			equal(frag.firstChild.nextSibling.nodeType, 3, "the next sibling is a TextNode");
 			equal(frag.firstChild.nextSibling.nextSibling, undefined, "there are no more nodes");
 		});
+		
+		test("#each passed a method (2001)", function(){
+			var users = new can.List([
+				{name: "Alexis", num: 4, age: 88},
+				{name: "Brian", num: 2, age: 31}
+			]);
+			
+			var template = can.stache("<div>{{#each people}}<span/>{{/each}}</div>");
+			
+			var VM = can.Map.extend({
+				people: function() {
+					return this.attr("users");
+				},
+				remove: function() {
+					$('#content').empty();
+				}
+			});
+			
+			var frag = template(new VM({
+				users: users
+			})),
+				div = frag.firstChild,
+				spans = div.getElementsByTagName("span");
+			
+			equal(spans.length, 2, "two spans");
+			
+			can.append(this.$fixture,frag);
+			
+			stop();
+			setTimeout(function(){
+				start();
+				can.remove( can.$(div) );
+				ok(true, "removed without breaking");
+			},10);
+			
+			
+		});
 
 		// PUT NEW TESTS RIGHT BEFORE THIS!
 	}


### PR DESCRIPTION
Fixes #2001

For now, I'm going to add a `callMethodsOnObservables` special flag to can.compute.read that HelperScopeLookup expressions will use to say "give me the function, unless it's on a can.Map. If it is on a can.Map, call the function and give a compute".