### PR TITLE
Fix wrong number of parameters when calling 'setup' in 'can/map/attributes'

### DIFF
--- a/map/attributes/attributes.js
+++ b/map/attributes/attributes.js
@@ -89,9 +89,9 @@ steal('can/util', 'can/map', 'can/list', function (can, Map) {
 		 * functionality for attributes.
 		 *
 		 */
-		clss.setup = function (superClass, stat, proto) {
+		clss.setup = function (superClass, fullName, stat, proto) {
 			var self = this;
-			oldSetup.call(self, superClass, stat, proto);
+			oldSetup.call(self, superClass, fullName, stat, proto);
 			can.each(['attributes'], function (name) {
 				if (!self[name] || superClass[name] === self[name]) {
 					self[name] = {};


### PR DESCRIPTION
Errors are encountered when using 'can/map/attributes' due to improper number of parameters used in can.Map/Model 'setup' wrapper