### PR TITLE
Docs: Add reference to new bindings in Stache docs

### DIFF
--- a/view/stache/doc/livebinding.md
+++ b/view/stache/doc/livebinding.md
@@ -48,3 +48,13 @@ update the paragraph tag to reflect the new value.
 
 
 For more information visit the [can.Map] documentation.
+
+### Binding between components
+If you are looking for information on bindings between components like this:
+```
+(event)="key()" for event binding.
+{prop}="key" for one-way binding to a child.
+{^prop}="key" for one-way binding to a parent.
+{(prop)}="key" for two-way binding.
+```
+See [can.view.bindings].


### PR DESCRIPTION
I've watched 3 people look for the docs on view-bindings inside the Stache docs.  This seems like the most-logical place to create a link between the sections.  I put the code example in place so people will see what they're looking for because they're probably not going to recognize it by name.   `can.view.bindings` won't ring a bell for people on the first time in the docs.