### PR TITLE
Refactoring Construct.prototype._initializing to __.inSetup

### DIFF
--- a/construct/construct.js
+++ b/construct/construct.js
@@ -191,17 +191,17 @@ steal('can/util/string', function (can) {
 			// Get a raw instance object (`init` is not called).
 			var inst = this.instance(),
 				args;
-			inst._initializing = true;
 			// Call `setup` if there is a `setup`
 			if (inst.setup) {
+				inst.__inSetup = true;
 				args = inst.setup.apply(inst, arguments);
+				delete inst.__inSetup;
 			}
-			// Call `init` if there is an `init`  
+			// Call `init` if there is an `init`
 			// If `setup` returned `args`, use those as the arguments
 			if (inst.init) {
 				inst.init.apply(inst, args || arguments);
 			}
-			delete inst._initializing;
 			return inst;
 		},
 		// Overwrites an object with methods. Used in the `super` plugin.

--- a/list/sort/sort_test.js
+++ b/list/sort/sort_test.js
@@ -628,11 +628,32 @@ steal("can/list/sort", "can/test", "can/view/mustache", "can/view/stache", "can/
 			expected.push(value);
 			expected.sort(can.List.prototype._comparator);
 			sorted.push(value);
-			
+
 			can.each(expected, function (value, index) {
 				equal(value, sorted.attr(index),
 					'Sort plugin output matches native output');
 			});
 		});
+	});
+
+	test('set comparator on init', function() {
+		var Item = can.Map.extend();
+		Item.List = Item.List.extend({
+			init: function() {
+				this.attr('comparator', 'isPrimary');
+			}
+		});
+
+		var items = [
+			{ isPrimary: false },
+			{ isPrimary: true },
+			{ isPrimary: false }
+		];
+
+		deepEqual(new Item.List(items).serialize(), [
+			{ isPrimary: false },
+			{ isPrimary: false },
+			{ isPrimary: true }
+		]);
 	});
 });

--- a/map/bubble.js
+++ b/map/bubble.js
@@ -28,7 +28,7 @@ steal('can/util', function(can){
 			// should setup bubbling if this is the first time 
 			// an event that bubbles is bound.
 			bind: function(parent, eventName) {
-				if (!parent._initializing ) {
+				if (!parent.__inSetup ) {
 					
 					var bubbleEvents = bubble.events(parent, eventName),
 						len = bubbleEvents.length,

--- a/map/map.js
+++ b/map/map.js
@@ -283,7 +283,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 					var first = attr.substr(0, dotIndex),
 						second = attr.substr(dotIndex+1);
 
-					current =  this._initializing ? undefined : this.___get( first );
+					current =  this.__inSetup ? undefined : this.___get( first );
 
 					if( can.isMapLike(current) ) {
 						current._set(second, value);
@@ -292,7 +292,7 @@ steal('can/util', 'can/util/bind','./bubble.js', './map_helpers.js','can/constru
 					}
 
 				} else {
-					current = this._initializing ? undefined : this.___get( attr );
+					current = this.__inSetup ? undefined : this.___get( attr );
 
 					// //Convert if there is a converter.  Remove in 3.0.
 					if (this.__convert) {

--- a/util/batch/batch.js
+++ b/util/batch/batch.js
@@ -215,7 +215,7 @@ steal('can/util/can.js', function (can) {
 		 */
 		trigger: function (item, event, args) {
 			// Don't send events if initalizing.
-			if (!item._initializing) {
+			if (!item.__inSetup) {
 				event = typeof event === 'string' ? {
 					type: event,
 					batchNum: can.batch.batchNum

--- a/util/bind/bind.js
+++ b/util/bind/bind.js
@@ -13,7 +13,7 @@ steal('can/util', function (can) {
 		can.addEvent.apply(this, arguments);
 		// If not initializing, and the first binding
 		// call bindsetup if the function exists.
-		if (!this._initializing) {
+		if (!this.__inSetup) {
 			if (!this._bindings) {
 				this._bindings = 1;
 				// setup live-binding


### PR DESCRIPTION
Allows for the triggering of events within a construct's init() method to preserve backwards compat.