### PR TITLE
Allow relative can-imports

### DIFF
--- a/build/config_meta_defaults.js
+++ b/build/config_meta_defaults.js
@@ -33,7 +33,7 @@ var reverseNormalize = function(name, load, baseName, baseLoad){
 	if(name === "dojo" || name === "dojo/dojo") {
 		return "dojo/main";
 	}
-	
+
 	if(name === "can") {
 		return name;
 	}
@@ -45,9 +45,9 @@ var reverseNormalize = function(name, load, baseName, baseLoad){
 	var parts = name.split("/");
 	if(parts.length > 1) {
 		parts.splice(parts.length-2,1);
-	} 
+	}
 	return "can/"+parts.join("/");
-	
+
 };
 var path = require("path");
 
@@ -86,7 +86,8 @@ module.exports = function(){
 					return true;
 				}
 			}, function(moduleName) {
-					if(moduleName.indexOf('/system') !== -1) {
+					if(moduleName.indexOf('/system') !== -1 ||
+						moduleName.indexOf('/add_bundles') !== -1) {
 						return true;
 					}
 			}])

--- a/test/builders/steal-tools/import/app.stache
+++ b/test/builders/steal-tools/import/app.stache
@@ -1,7 +1,7 @@
 <can-import from="import/other" />
 
 {{#eq page "list"}}
-	<can-import from="import/thing">
+	<can-import from="./thing">
 		<span>thing</span>
 	</can-import>
 {{/if}}

--- a/test/builders/steal-tools/test.js
+++ b/test/builders/steal-tools/test.js
@@ -131,7 +131,6 @@ describe("Building steal projects", function(){
 		rmdir(__dirname + "/import/dist", function(error){
 			if(error) return done(error);
 
-			console.log("building it");
 			stealTools.build({
 				config: __dirname + "/config.js",
 				main: "import/app",

--- a/view/stache/add_bundles.js
+++ b/view/stache/add_bundles.js
@@ -1,0 +1,32 @@
+/* globals Promise */
+steal("@loader", "can/util/can.js", function(loader, can){
+
+	// Given a module name normalize it and add it to the loader.bundle array.
+	return function(dynamicImports, parentName) {
+		if(!dynamicImports.length) {
+			return Promise.resolve();
+		}
+
+		// In the build the "main" loader is the localLoader
+		var localLoader = loader.localLoader || loader;
+		var bundle = localLoader.bundle;
+		if(!bundle) {
+			bundle = localLoader.bundle = [];
+		}
+
+		var bundleNormalizes = [];
+		can.each(dynamicImports, function(moduleName){
+			var bundleNormalize = loader.normalize(moduleName, parentName)
+				.then(function(moduleName){
+					if(!~bundle.indexOf(moduleName)) {
+						bundle.push(moduleName);
+					}
+				});
+
+			bundleNormalizes.push(bundleNormalize);
+		});
+
+		return Promise.all(bundleNormalizes);
+	};
+
+});

--- a/view/stache/system.js
+++ b/view/stache/system.js
@@ -1,37 +1,20 @@
 "format steal";
-steal("@loader", "can/util/can.js", "can/view/stache", "can/view/stache/intermediate_and_imports.js",function(loader, can, stache, getIntermediateAndImports){
-
-	function addBundles(dynamicImports) {
-		if(!dynamicImports.length) {
-			return;
-		}
-
-		// In the build the "main" loader is the localLoader
-		var localLoader = loader.localLoader || loader;
-		var bundle = localLoader.bundle;
-		if(!bundle) {
-			bundle = localLoader.bundle = [];
-		}
-
-		can.each(dynamicImports, function(moduleName){
-			if(!~bundle.indexOf(moduleName)) {
-				bundle.push(moduleName);
-			}
-		});
-	}
+steal("can/view/stache", "can/view/stache/intermediate_and_imports.js", "can/view/stache/add_bundles.js",function(stache, getIntermediateAndImports, addBundles){
 
 	function translate(load) {
 		var intermediateAndImports = getIntermediateAndImports(load.source);
 
 		// Add bundle configuration for these dynamic imports
-		addBundles(intermediateAndImports.dynamicImports);
+		return addBundles(intermediateAndImports.dynamicImports, load.name).then(function(){
 
-		intermediateAndImports.imports.unshift("can/view/stache/mustache_core");
-		intermediateAndImports.imports.unshift("can/view/stache/stache");
-		intermediateAndImports.imports.unshift("module");
+			intermediateAndImports.imports.unshift("can/view/stache/mustache_core");
+			intermediateAndImports.imports.unshift("can/view/stache/stache");
+			intermediateAndImports.imports.unshift("module");
 
-		return template(intermediateAndImports.imports,
-										intermediateAndImports.intermediate);
+			return template(intermediateAndImports.imports,
+											intermediateAndImports.intermediate);
+
+		});
 	}
 
 	function template(imports, intermediate){


### PR DESCRIPTION
This fixes our can/view/stache/system plugin to normalize the dynamic
module names before adding them to System.bundle. This is needed because
steal-tools normalizes the bundle names and if the names are relative it
will throw an exception. Fixes #2037 