### PR TITLE
Add can/map/define to default can require

### DIFF
--- a/can.js
+++ b/can.js
@@ -1,4 +1,4 @@
-steal('can/util', 'can/control/route', 'can/model', 
+steal('can/util', 'can/control/route', 'can/model', 'can/map/define',
 	'can/view/mustache', 'can/component', function(can) {
 	return can;
 });

--- a/map/define/define.js
+++ b/map/define/define.js
@@ -1,4 +1,8 @@
-steal('can/util','can/map/map_helpers.js', 'can/observe', function (can, mapHelpers) {
+steal('can/util','can/map/map_helpers.js', 'can/map', 'can/compute', function (can, mapHelpers) {
+	if(can.define) {
+		return;
+	}
+
 	var define = can.define = {};
 	
 	var getPropDefineBehavior = function(behavior, attr, define) {


### PR DESCRIPTION
This adds `can/map/define` by default when someone loads the `can` module with a module loader. Closes #2040